### PR TITLE
Internals: Refactor handling of empty and invalid strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Breaking: Remove default `Display` implementation for most `ua` wrapper types (using the `Debug`
+  implementation is more appropriate in these cases)
+
 ## [0.2.2] - 2024-01-12
 
 [0.2.2]: https://github.com/HMIProject/open62541/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Breaking: Remove default `Display` implementation for most `ua` wrapper types (using the `Debug`
-  implementation is more appropriate in these cases)
+  implementation is more appropriate in these cases).
+
+### Fixed
+
+- Fix handling of empty and invalid strings.
 
 ## [0.2.2] - 2024-01-12
 

--- a/examples/async_browse.rs
+++ b/examples/async_browse.rs
@@ -18,12 +18,7 @@ async fn main() -> anyhow::Result<()> {
             return format!("{node_id}");
         };
 
-        let info = vec![
-            node.display_name().text().to_string().into_owned(),
-            node.node_class().to_string(),
-        ];
-
-        let info = info.join(", ");
+        let info = format!("{}, {:?}", node.display_name().text(), node.node_class());
 
         format!("{name} ({info}) -> {node_id}")
     });

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -348,12 +348,6 @@ macro_rules! data_type {
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                <Self as std::fmt::Display>::fmt(self, f)
-            }
-        }
-
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let output = <Self as crate::DataType>::print(self);
                 let string = output.as_ref().and_then(|output| output.as_str());
                 f.write_str(string.unwrap_or(stringify!($name)))

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,11 +9,12 @@ use crate::ua;
 ///
 /// [`UA_STATUSCODE_GOOD`]: open62541_sys::UA_STATUSCODE_GOOD
 #[derive(Debug, Error)]
-#[error("{0}")]
 pub enum Error {
     /// Error from server.
+    #[error("{0:?}")]
     Server(ua::StatusCode),
     /// Internal error.
+    #[error("{0}")]
     Internal(&'static str),
 }
 

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -15,5 +15,5 @@ pub use self::{
     monitored_item_id::MonitoredItemId,
     node_class_mask::NodeClassMask,
     subscription_id::SubscriptionId,
-    values::{PointerValue, ScalarValue, VariantValue},
+    values::{ArrayValue, ScalarValue, VariantValue},
 };

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -15,5 +15,5 @@ pub use self::{
     monitored_item_id::MonitoredItemId,
     node_class_mask::NodeClassMask,
     subscription_id::SubscriptionId,
-    values::{ScalarValue, VariantValue},
+    values::{PointerValue, ScalarValue, VariantValue},
 };

--- a/src/ua/data_types/qualified_name.rs
+++ b/src/ua/data_types/qualified_name.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{ua, DataType as _};
 
 crate::data_type!(QualifiedName);
@@ -12,14 +14,14 @@ impl QualifiedName {
     pub fn name(&self) -> &ua::String {
         ua::String::raw_ref(&self.0.name)
     }
+}
 
-    #[allow(clippy::inherent_to_string_shadow_display)] // TODO: Fix conflicting definitions.
-    #[must_use]
-    pub fn to_string(&self) -> String {
+impl fmt::Display for QualifiedName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let namespace_index = self.namespace_index();
         if namespace_index == 0 {
-            return self.name().to_string().to_string();
+            return write!(f, "{}", self.name());
         }
-        format!("{namespace_index}:{}", self.name().to_string())
+        write!(f, "{namespace_index}:{}", self.name())
     }
 }

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -25,7 +25,7 @@ impl String {
         }
     }
 
-    /// Returns string as [`str`] slice.
+    /// Returns string as string slice.
     ///
     /// This may return [`None`] when the string itself is invalid or it is not valid UTF-8.
     #[must_use]

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi::CString, slice, str, string};
+use std::{borrow::Cow, ffi::CString, fmt, slice, str, string};
 
 use open62541_sys::UA_String_fromChars;
 
@@ -22,6 +22,13 @@ impl String {
         // TODO: Handle `UA_EMPTY_ARRAY_SENTINEL` and `ptr::null()` correctly.
         let slice = unsafe { slice::from_raw_parts(self.0.data, self.0.length) };
         string::String::from_utf8_lossy(slice)
+    }
+}
+
+impl fmt::Display for String {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display invalid strings as empty strings.
+        f.write_str(self.as_str().unwrap_or(""))
     }
 }
 
@@ -62,5 +69,12 @@ mod tests {
         let str: ua::String = "".parse().expect("should parse empty string");
         assert_eq!(str.as_str().expect("should display empty string"), "");
         assert_eq!(str.to_string(), "");
+    }
+
+    #[test]
+    fn valid_string() {
+        let str: ua::String = "lorem ipsum".parse().expect("should parse string");
+        assert_eq!(str.as_str().expect("should display string"), "lorem ipsum");
+        assert_eq!(str.to_string(), "lorem ipsum");
     }
 }

--- a/src/ua/values.rs
+++ b/src/ua/values.rs
@@ -32,31 +32,29 @@ pub enum ScalarValue {
 /// Value that may be invalid or empty.
 ///
 /// For some types (notably arrays and strings) OPC UA defines different states: an empty state and
-/// an invalid state, in addition to the regular valid state.
+/// an invalid state, in addition to the regular valid/non-empty state.
 #[derive(Debug, Clone)]
-pub enum MaybeValue<T> {
+pub enum ArrayValue<T> {
     Invalid,
     Empty,
-    Valid(T),
+    Valid(NonNull<T>),
 }
 
-pub type PointerValue<T> = MaybeValue<NonNull<T>>;
-
-impl<T> PointerValue<T> {
-    /// Creates wrapped pointer.
+impl<T> ArrayValue<T> {
+    /// Creates appropriate [`ArrayValue`].
     ///
     /// This checks for different states (null pointer, sentinel value) and returns the appropriate
-    /// value from [`MaybeValue`].
-    pub fn from_raw(data: *mut T) -> Self {
+    /// value from [`ArrayValue`].
+    pub fn from_ptr(data: *mut T) -> Self {
         // Check for sentinel value first. We must not treat it as valid pointer below.
         if data.cast_const().cast::<c_void>() == unsafe { UA_EMPTY_ARRAY_SENTINEL_ } {
-            return PointerValue::Empty;
+            return ArrayValue::Empty;
         }
 
         // Null pointers are regarded as "invalid" data by `open62541`.
         match NonNull::new(data) {
-            Some(data) => PointerValue::Valid(data),
-            None => PointerValue::Invalid,
+            Some(data) => ArrayValue::Valid(data),
+            None => ArrayValue::Invalid,
         }
     }
 }


### PR DESCRIPTION
## Description

This improves handling of empty and invalid strings (as defined by OPC UA which differentiates between these states). We also prepare the types for handling the same situation for OPC UA arrays (which may also be empty or invalid).

This also removes the default `Display` implementation for `ua` wrapper types, adding it back only where it makes sense. This is a breaking change and will result in a minor version bump (we have not released version 1 yet).