### PR TITLE
Include values in log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix handling of empty and invalid strings.
+- Include values in log messages.
 
 ## [0.2.2] - 2024-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix handling of empty and invalid strings.
-- Include values in log messages.
+- Include values in log messages (#22).
 
 ## [0.2.2] - 2024-01-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a66c1c16c1f531d4fab57db496f9d2895a3feab93ae21e611165f17a7ab6a27"
+checksum = "de2e45b35ac7e0d0ab8c3c8936d7fcb3116d32459298f83f468c91e917ca387b"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2e45b35ac7e0d0ab8c3c8936d7fcb3116d32459298f83f468c91e917ca387b"
+checksum = "c932eca2a504c3ceb6a4950d9c55c4e7cd1bd3ccc1e4febbaea19d4f330df71f"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.1.3"
+open62541-sys = "0.2.0"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.2.0"
+open62541-sys = "0.2.1"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{c_char, c_ulong, c_void, CStr, CString},
+    ffi::{c_char, c_void, CStr, CString},
     ptr,
     time::Duration,
 };
@@ -238,7 +238,7 @@ fn format_message(msg: *const c_char, args: open62541_sys::va_list_) -> Option<V
         let result = unsafe {
             vsnprintf(
                 msg_buffer.as_mut_ptr().cast::<c_char>(),
-                c_ulong::try_from(msg_buffer.len()).expect("string should fit into memory"),
+                msg_buffer.len(),
                 msg,
                 args,
             )

--- a/src/client.rs
+++ b/src/client.rs
@@ -168,7 +168,8 @@ fn set_default_logger(config: &mut UA_ClientConfig) {
         } else if level == UA_LogLevel::UA_LOGLEVEL_TRACE {
             log::trace!("{msg}");
         } else {
-            // TODO: Handle unexpected level.
+            // Handle unexpected level by escalating to error.
+            log::error!("{msg}");
         }
     }
 

--- a/src/ua/values.rs
+++ b/src/ua/values.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, ptr::NonNull};
 
-use open62541_sys::UA_EMPTY_ARRAY_SENTINEL_;
+use open62541_sys::UA_EMPTY_ARRAY_SENTINEL;
 
 use crate::ua;
 
@@ -47,7 +47,7 @@ impl<T> ArrayValue<T> {
     /// value from [`ArrayValue`].
     pub fn from_ptr(data: *mut T) -> Self {
         // Check for sentinel value first. We must not treat it as valid pointer below.
-        if data.cast_const().cast::<c_void>() == unsafe { UA_EMPTY_ARRAY_SENTINEL_ } {
+        if data.cast_const().cast::<c_void>() == unsafe { UA_EMPTY_ARRAY_SENTINEL } {
             return ArrayValue::Empty;
         }
 


### PR DESCRIPTION
## Description

This makes sure to include values when printing out log messages. This is done by passing the format string with variadic arguments to `vsnprintf()` to handle all the formatting.

Fixes #22