### PR TITLE
Add method to fetch current client state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Allow fetching current client state to periodically check for disconnect.
+
 ### Changed
 
 - Breaking: Remove default `Display` implementation for most `ua` wrapper types (using the `Debug`

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -61,6 +61,15 @@ impl AsyncClient {
         }
     }
 
+    /// Gets current channel and session state, and connect status.
+    pub fn state(&self) -> Result<ua::ClientState, Error> {
+        let Ok(mut client) = self.client.lock() else {
+            return Err(Error::internal("should be able to lock client"));
+        };
+
+        Ok(client.state())
+    }
+
     /// Reads value from server.
     ///
     /// # Errors

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -62,6 +62,10 @@ impl AsyncClient {
     }
 
     /// Gets current channel and session state, and connect status.
+    ///
+    /// # Errors
+    ///
+    /// This only fails when the client has an internal error.
     pub fn state(&self) -> Result<ua::ClientState, Error> {
         let Ok(mut client) = self.client.lock() else {
             return Err(Error::internal("should be able to lock client"));

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -5,15 +5,19 @@ mod client;
 mod data_types;
 mod monitored_item_id;
 mod node_class_mask;
+mod secure_channel_state;
+mod session_state;
 mod subscription_id;
 mod values;
 
 pub use self::{
     array::Array,
-    client::Client,
+    client::{Client, ClientState},
     data_types::*,
     monitored_item_id::MonitoredItemId,
     node_class_mask::NodeClassMask,
+    secure_channel_state::SecureChannelState,
+    session_state::SessionState,
     subscription_id::SubscriptionId,
     values::{ArrayValue, ScalarValue, VariantValue},
 };

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -1,6 +1,20 @@
 use std::ptr::NonNull;
 
-use open62541_sys::{UA_Client, UA_Client_delete, UA_Client_new};
+use open62541_sys::{UA_Client, UA_Client_delete, UA_Client_getState, UA_Client_new};
+
+use crate::{ua, DataType as _};
+
+/// Combined state of [`Client`] or [`AsyncClient`].
+///
+/// [`AsyncClient`]: crate::AsyncClient
+pub struct ClientState {
+    pub channel_state: ua::SecureChannelState,
+    pub session_state: ua::SessionState,
+    /// The `connect_status` is set if the client connection (including reconnects) has failed and
+    /// the client has to "give up". If the `connect_status` is not set, the client still has hope
+    /// to connect or recover.
+    pub connect_status: ua::StatusCode,
+}
 
 /// Wrapper for [`UA_Client`] from [`open62541_sys`].
 ///
@@ -23,6 +37,30 @@ impl Client {
     #[must_use]
     pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_Client {
         self.0.as_ptr()
+    }
+
+    /// Gets current channel and session state, and connect status.
+    pub(crate) fn state(&mut self) -> ClientState {
+        log::debug!("Getting state");
+
+        let mut channel_state = ua::SecureChannelState::init();
+        let mut session_state = ua::SessionState::init();
+        let mut connect_status = ua::StatusCode::init();
+
+        unsafe {
+            UA_Client_getState(
+                self.as_mut_ptr(),
+                channel_state.as_mut_ptr(),
+                session_state.as_mut_ptr(),
+                connect_status.as_mut_ptr(),
+            );
+        }
+
+        ClientState {
+            channel_state,
+            session_state,
+            connect_status,
+        }
     }
 }
 

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -4,9 +4,10 @@ use open62541_sys::{UA_Client, UA_Client_delete, UA_Client_getState, UA_Client_n
 
 use crate::{ua, DataType as _};
 
-/// Combined state of [`Client`] or [`AsyncClient`].
+/// Combined state for [`Client`] and [`AsyncClient`].
 ///
 /// [`AsyncClient`]: crate::AsyncClient
+#[allow(clippy::module_name_repetitions)]
 pub struct ClientState {
     pub channel_state: ua::SecureChannelState,
     pub session_state: ua::SessionState,

--- a/src/ua/secure_channel_state.rs
+++ b/src/ua/secure_channel_state.rs
@@ -1,0 +1,18 @@
+use open62541_sys::UA_SecureChannelState;
+
+/// Wrapper for secure channel state from [`open62541_sys`].
+pub struct SecureChannelState(UA_SecureChannelState);
+
+impl SecureChannelState {
+    /// Creates wrapper initialized with defaults.
+    #[must_use]
+    pub(crate) const fn init() -> Self {
+        Self(UA_SecureChannelState::UA_SECURECHANNELSTATE_FRESH)
+    }
+
+    /// Returns mutable pointer to value.
+    #[must_use]
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_SecureChannelState {
+        &mut self.0
+    }
+}

--- a/src/ua/session_state.rs
+++ b/src/ua/session_state.rs
@@ -1,0 +1,18 @@
+use open62541_sys::UA_SessionState;
+
+/// Wrapper for secure channel state from [`open62541_sys`].
+pub struct SessionState(UA_SessionState);
+
+impl SessionState {
+    /// Creates wrapper initialized with defaults.
+    #[must_use]
+    pub(crate) const fn init() -> Self {
+        Self(UA_SessionState::UA_SESSIONSTATE_CLOSED)
+    }
+
+    /// Returns mutable pointer to value.
+    #[must_use]
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_SessionState {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
## Description

This adds the method `state()` to get the current client state, including connection status.

If `connection_status.is_good()` returns `true` the client is connected or trying to reconnect. Otherwise the connection has permanently failed and the client should be discarded and a new client should be created to try again later.

We may want to add an asynchronous interface later to get events whenever the state/status changes.