### PR TITLE
Internal: Use named exports to clarify intentions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558fefb0b0116be94cd24a65e5d0156ccfdc6b7241c6933cf067cc7d8b4d79e3"
+checksum = "8774f7477e6e3a0a6e617ed600dabbb839f996a5ac1324533a486f59bfdf08ec"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.2.2"
+open62541-sys = "0.3.2"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This uses the explicitly named exports from https://github.com/HMIProject/open62541-sys/pull/11.