### PR TITLE
Enable lint `unsafe_op_in_unsafe_fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ time = ["dep:time"]
 tokio = ["dep:tokio"]
 
 [lints.rust]
-warnings = "warn"
 future_incompatible = "warn"
 let_underscore = "warn"
 nonstandard_style = "warn"
@@ -53,12 +52,13 @@ rust_2018_compatibility = "warn"
 rust_2018_idioms = "warn"
 rust_2021_compatibility = "warn"
 unused = "warn"
+warnings = "warn"
 
 [lints.clippy]
-pedantic = "warn"
 clone_on_ref_ptr = "warn"
 missing_const_for_fn = "warn"
 mod_module_files = "warn"
+pedantic = "warn"
 
 [[example]]
 name = "async_browse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ nonstandard_style = "warn"
 rust_2018_compatibility = "warn"
 rust_2018_idioms = "warn"
 rust_2021_compatibility = "warn"
+unsafe_op_in_unsafe_fn = "warn"
 unused = "warn"
 warnings = "warn"
 


### PR DESCRIPTION
## Description

This enables the lint [`unsafe_op_in_unsafe_fn`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-op-in-unsafe-fn) to help us spot unsafe operations inside `unsafe fn` and uphold their invariants.