### PR TITLE
Keep MSRV as low as possible

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Rust toolchain
         # Use specific Rust version that is the minimum supported `rust-version`
         # (MSRV) from `Cargo.toml`.
-        uses: dtolnay/rust-toolchain@1.74
+        uses: dtolnay/rust-toolchain@1.72
         with:
           # This target also needs to be specified explicitly in every build step!
           # Otherwise the default toolchain might be used unintentionally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ name = "open62541"
 version = "0.3.0"
 authors = ["HMI Project"]
 edition = "2021"
-# Keep the MSRV number here in sync with `test.yaml`.
-rust-version = "1.74"
+# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.72 (the
+# linux-musl build fails with earlier versions).
+rust-version = "1.72"
 description = "High-level, safe bindings for the C99 library open62541, an open source and free implementation of OPC UA (OPC Unified Architecture)."
 documentation = "https://docs.rs/open62541"
 readme = "README.md"


### PR DESCRIPTION
## Description

In #33 the minimum supported Rust version (MSRV) was increased from 1.71 to 1.74 to fix the linux-musl build, as shown in https://github.com/HMIProject/open62541/pull/33#issuecomment-1914380425. However we only need to bump the MSRV to 1.72 for the same effect, cf. https://github.com/HMIProject/open62541-sys/pull/14.

We want to keep the MSRV as low as possible to allow the crate to be used in as many environments as we can support.