### PR TITLE
Simplify serialization of `ua::String`, `ua::DateTime`, `ua::Variant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Breaking: Renamed `ua::DateTime::as_datetime()` to `ua::DateTime::to_utc()`.
+- Use RFC 3339 variant of ISO 8601 for `ua::DateTime` serialization.
 
 ## [0.3.0] - 2024-01-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1.35.1", features = ["macros"] }
 
 [features]
 default = ["serde", "time", "tokio"]
-serde = ["dep:serde", "dep:serde_json", "time?/serde"]
+serde = ["dep:serde", "dep:serde_json", "time?/formatting", "time?/serde"]
 time = ["dep:time"]
 tokio = ["dep:tokio"]
 

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -82,6 +82,18 @@ macro_rules! primitive {
                     self.0
                 }
             }
+
+            #[cfg(feature = "serde")]
+            impl serde::Serialize for $name {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    paste::paste! {
+                        serializer.[<serialize_ $type>](self.0)
+                    }
+                }
+            }
         )*
     };
 }

--- a/src/ua/data_types/date_time.rs
+++ b/src/ua/data_types/date_time.rs
@@ -31,6 +31,18 @@ impl TryFrom<time::OffsetDateTime> for DateTime {
     }
 }
 
+#[cfg(all(feature = "serde", feature = "time"))]
+impl serde::Serialize for DateTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_utc()
+            .ok_or(serde::ser::Error::custom("DateTime should be in range"))
+            .and_then(|dt| time::serde::rfc3339::serialize(&dt, serializer))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "time")]

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -82,7 +82,7 @@ impl str::FromStr for String {
     }
 }
 
-#[cfg(all(feature = "serde", feature = "time"))]
+#[cfg(feature = "serde")]
 impl serde::Serialize for String {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -82,6 +82,18 @@ impl str::FromStr for String {
     }
 }
 
+#[cfg(all(feature = "serde", feature = "time"))]
+impl serde::Serialize for String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str()
+            .ok_or(serde::ser::Error::custom("String should be valid"))
+            .and_then(|str| serializer.serialize_str(str))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ua;

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -137,11 +137,7 @@ mod serde {
             );
 
             // Data type ns=0;i=12
-            if let Some(value) = self
-                .to_scalar::<ua::String>()
-                .as_ref()
-                .and_then(|value| value.as_str())
-            {
+            if let Some(value) = self.as_scalar().and_then(ua::String::as_str) {
                 return serializer.serialize_str(value);
             }
 

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -155,3 +155,89 @@ mod serde {
         }
     }
 }
+
+#[cfg(feature = "serde")]
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use crate::{ua, DataType as _};
+
+    #[test]
+    fn serialize_bool() {
+        // Value `true`
+        let ua_bool = ua::Boolean::new(true);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_bool);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"true"#, json);
+
+        // Value `false`
+        let ua_bool = ua::Boolean::new(false);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_bool);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"false"#, json);
+    }
+
+    #[test]
+    fn serialize_int() {
+        // Byte (unsigned)
+        let ua_byte = ua::Byte::new(42);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_byte);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"42"#, json);
+
+        // Int16 (signed)
+        let ua_int16 = ua::Int16::new(-12345);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_int16);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"-12345"#, json);
+
+        // UInt32 (unsigned)
+        let ua_uint32 = ua::UInt32::new(123456789);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_uint32);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"123456789"#, json);
+
+        // Int64 (signed)
+        let ua_int64 = ua::Int64::new(-7077926753204279296);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_int64);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"-7077926753204279296"#, json);
+    }
+
+    #[test]
+    fn serialize_float() {
+        // Float
+        let ua_float = ua::Float::new(123.4567);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_float);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"123.4567"#, json);
+
+        // Double
+        let ua_double = ua::Double::new(-98765432.1);
+        let ua_variant = ua::Variant::init().with_scalar(&ua_double);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#"-98765432.1"#, json);
+    }
+
+    #[test]
+    fn serialize_string() {
+        // Empty string
+        let ua_string = ua::String::from_str("").unwrap();
+        let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#""""#, json);
+
+        // Short string
+        let ua_string = ua::String::from_str("lorem ipsum").unwrap();
+        let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#""lorem ipsum""#, json);
+
+        // Special characters
+        let ua_string = ua::String::from_str(r#"a'b"c{dẞe​f"#).unwrap();
+        let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+        let json = serde_json::to_string(&ua_variant).unwrap();
+        assert_eq!(r#""a'b\"c{dẞe​f""#, json);
+    }
+}

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -99,36 +99,6 @@ impl serde::Serialize for Variant {
     where
         S: serde::Serializer,
     {
-        macro_rules! serialize_raw {
-            ($self:ident, $serializer:ident, [ $( ($name:ident, $type:ty) ),* $(,)? ]) => {
-                $(
-                    if let Some(value) = $self.to_scalar::<crate::ua::$name>() {
-                        paste::paste! {
-                            return $serializer.[<serialize_ $type>](value.into_raw());
-                        }
-                    }
-                )*
-            };
-        }
-
-        serialize_raw!(
-            self,
-            serializer,
-            [
-                (Boolean, bool), // Data type ns=0;i=1
-                (SByte, i8),     // Data type ns=0;i=2
-                (Byte, u8),      // Data type ns=0;i=3
-                (Int16, i16),    // Data type ns=0;i=4
-                (UInt16, u16),   // Data type ns=0;i=5
-                (Int32, i32),    // Data type ns=0;i=6
-                (UInt32, u32),   // Data type ns=0;i=7
-                (Int64, i64),    // Data type ns=0;i=8
-                (UInt64, u64),   // Data type ns=0;i=9
-                (Float, f32),    // Data type ns=0;i=10
-                (Double, f64),   // Data type ns=0;i=11
-            ]
-        );
-
         macro_rules! serialize {
             ($self:ident, $serializer:ident, [ $( $( #[cfg($cfg: meta)] )? $name:ident ),* $(,)? ]) => {
                 $(
@@ -144,7 +114,18 @@ impl serde::Serialize for Variant {
             self,
             serializer,
             [
-                String, // Data type ns=0;i=12
+                Boolean, // Data type ns=0;i=1
+                SByte,   // Data type ns=0;i=2
+                Byte,    // Data type ns=0;i=3
+                Int16,   // Data type ns=0;i=4
+                UInt16,  // Data type ns=0;i=5
+                Int32,   // Data type ns=0;i=6
+                UInt32,  // Data type ns=0;i=7
+                Int64,   // Data type ns=0;i=8
+                UInt64,  // Data type ns=0;i=9
+                Float,   // Data type ns=0;i=10
+                Double,  // Data type ns=0;i=11
+                String,  // Data type ns=0;i=12
                 #[cfg(feature = "time")]
                 DateTime, // Data type ns=0;i=13
             ]


### PR DESCRIPTION
## Description

This refactors the logic for serializing String, DateTime, and Variant types. For DateTime, we now use the RFC 3339 variant of ISO 8601 instead of the default array serialization. It also adds tests for these.