### PR TITLE
Use custom error type for `TryFrom` conversion

### DIFF
--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -69,7 +69,7 @@ impl str::FromStr for String {
     /// let node_id: ua::String = "Lorem Ipsum".parse().unwrap();
     /// ```
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// The string slice must not contain any NUL bytes.
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
## Description

This is a followup to #40 and replaces the conversion error with our custom `Error` type to provide a consistent API. This has precedent in the `FromStr` conversions we already have for `ua::NodeId` and `ua::String`.