### PR TITLE
Fix copy/paste typo in docs

### DIFF
--- a/src/ua/secure_channel_state.rs
+++ b/src/ua/secure_channel_state.rs
@@ -1,6 +1,6 @@
 use open62541_sys::UA_SecureChannelState;
 
-/// Wrapper for secure channel state from [`open62541_sys`].
+/// Wrapper for [`UA_SecureChannelState`] from [`open62541_sys`].
 pub struct SecureChannelState(UA_SecureChannelState);
 
 impl SecureChannelState {

--- a/src/ua/session_state.rs
+++ b/src/ua/session_state.rs
@@ -1,6 +1,6 @@
 use open62541_sys::UA_SessionState;
 
-/// Wrapper for secure channel state from [`open62541_sys`].
+/// Wrapper for session state from [`open62541_sys`].
 pub struct SessionState(UA_SessionState);
 
 impl SessionState {

--- a/src/ua/session_state.rs
+++ b/src/ua/session_state.rs
@@ -1,6 +1,6 @@
 use open62541_sys::UA_SessionState;
 
-/// Wrapper for session state from [`open62541_sys`].
+/// Wrapper for [`UA_SessionState`] from [`open62541_sys`].
 pub struct SessionState(UA_SessionState);
 
 impl SessionState {


### PR DESCRIPTION
## Description

This fixes a trivial typo in the docs, likely introduced by copying/pasting an existing file.