### PR TITLE
Allow reading node attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Allow reading node attributes with `AsyncClient::read_attribute()`
+
 ## [0.4.0] - 2024-02-12
 
 [0.4.0]: https://github.com/HMIProject/open62541/compare/v0.3.0...v0.4.0

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -75,16 +75,37 @@ impl AsyncClient {
         Ok(client.state())
     }
 
-    /// Reads value from server.
+    /// Reads node attribute.
+    ///
+    /// To read only the value attribute, you can also use [`read_value()`].
+    ///
+    /// # Errors
+    ///
+    /// This fails when the node does not exist or the attribute cannot be read.
+    ///
+    /// [`read_value()`]: Self::read_value
+    pub async fn read_attribute(
+        &self,
+        node_id: &ua::NodeId,
+        attribute_id: &ua::AttributeId,
+    ) -> Result<ua::DataValue, Error> {
+        read_attribute(&self.client, node_id, attribute_id).await
+    }
+
+    /// Reads node value.
+    ///
+    /// To read other attributes, see [`read_attribute()`].
     ///
     /// # Errors
     ///
     /// This fails when the node does not exist or its value attribute cannot be read.
+    ///
+    /// [`read_attribute()`]: Self::read_attribute
     pub async fn read_value(&self, node_id: &ua::NodeId) -> Result<ua::DataValue, Error> {
-        read_attribute(&self.client, node_id, &ua::AttributeId::value()).await
+        read_attribute(&self.client, node_id, &ua::AttributeId::VALUE).await
     }
 
-    /// Writes value from server.
+    /// Writes node value.
     ///
     /// # Errors
     ///
@@ -94,7 +115,7 @@ impl AsyncClient {
         node_id: &ua::NodeId,
         value: &ua::DataValue,
     ) -> Result<(), Error> {
-        let attribute_id = ua::AttributeId::value();
+        let attribute_id = ua::AttributeId::VALUE;
 
         let request = ua::WriteRequest::init().with_nodes_to_write(&[ua::WriteValue::init()
             .with_node_id(node_id)
@@ -317,7 +338,7 @@ async fn read_attribute(
         status: UA_StatusCode,
         attribute: *mut UA_DataValue,
     ) {
-        log::debug!("readValueAttribute() completed");
+        log::debug!("readAttribute() completed");
 
         let status_code = ua::StatusCode::new(status);
 
@@ -350,7 +371,7 @@ async fn read_attribute(
             return Err(Error::internal("should be able to lock client"));
         };
 
-        log::debug!("Calling readValueAttribute(), node_id={node_id:?}");
+        log::debug!("Calling readAttribute(), node_id={node_id:?}");
 
         let read_value_id = ua::ReadValueId::init()
             .with_node_id(node_id)

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -102,7 +102,7 @@ impl AsyncClient {
     ///
     /// [`read_attribute()`]: Self::read_attribute
     pub async fn read_value(&self, node_id: &ua::NodeId) -> Result<ua::DataValue, Error> {
-        read_attribute(&self.client, node_id, &ua::AttributeId::VALUE).await
+        self.read_attribute(node_id, &ua::AttributeId::VALUE).await
     }
 
     /// Writes node value.

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -254,7 +254,7 @@ pub unsafe trait DataType: Clone {
     }
 }
 
-/// Define wrapper for OPC UA data type from [`open62541_sys`].
+/// Defines wrapper for OPC UA data type from [`open62541_sys`].
 ///
 /// This provides the basic interface to convert from and back into the [`open62541_sys`] types. Use
 /// another `impl` block to add additional methods to each type if necessary.
@@ -387,5 +387,41 @@ macro_rules! data_type {
 }
 
 pub(crate) use data_type;
+
+/// Defines known enum variants for wrapper.
+///
+/// This allows implementing data types that wrap an enum type from [`open62541_sys`]. This provides
+/// `const` members for each given variant and implements [`Display`]. Use this with [`data_type!`].
+///
+/// [`Display`]: std::fmt::Display
+macro_rules! enum_variants {
+    ($name:ident, $inner:ident, [$( $value:ident ),* $(,)?]) => {
+        impl $name {
+            $(
+                pub const $value: Self = Self(
+                    paste::paste! { open62541_sys::$inner::[<$inner:upper _ $value>] }
+                );
+            )*
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let str = match self.0 {
+                    $(
+                        paste::paste! { open62541_sys::$inner::[<$inner:upper _ $value>] } => {
+                            stringify!($value)
+                        },
+                    )*
+
+                    _ => return write!(f, "{}", self.as_u32()),
+                };
+
+                f.write_str(str)
+            }
+        }
+    };
+}
+
+pub(crate) use enum_variants;
 
 use crate::ua;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use self::{
     error::Error,
 };
 pub(crate) use self::{
-    data_type::data_type,
+    data_type::{data_type, enum_variants},
     service::{ServiceRequest, ServiceResponse},
 };
 

--- a/src/ua/data_types/attribute_id.rs
+++ b/src/ua/data_types/attribute_id.rs
@@ -1,39 +1,44 @@
-use std::{fmt, hash};
+use std::hash;
 
 use open62541_sys::UA_AttributeId;
 
 crate::data_type!(AttributeId, UInt32);
 
-impl AttributeId {
-    pub const NODEID: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_NODEID);
-    pub const NODECLASS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_NODECLASS);
-    pub const BROWSENAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_BROWSENAME);
-    pub const DISPLAYNAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DISPLAYNAME);
-    pub const DESCRIPTION: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DESCRIPTION);
-    pub const WRITEMASK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_WRITEMASK);
-    pub const USERWRITEMASK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERWRITEMASK);
-    pub const ISABSTRACT: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ISABSTRACT);
-    pub const SYMMETRIC: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_SYMMETRIC);
-    pub const INVERSENAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_INVERSENAME);
-    pub const CONTAINSNOLOOPS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_CONTAINSNOLOOPS);
-    pub const EVENTNOTIFIER: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_EVENTNOTIFIER);
-    pub const VALUE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_VALUE);
-    pub const DATATYPE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DATATYPE);
-    pub const VALUERANK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_VALUERANK);
-    pub const ARRAYDIMENSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ARRAYDIMENSIONS);
-    pub const ACCESSLEVEL: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVEL);
-    pub const USERACCESSLEVEL: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERACCESSLEVEL);
-    pub const MINIMUMSAMPLINGINTERVAL: Self =
-        Self(UA_AttributeId::UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL);
-    pub const HISTORIZING: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_HISTORIZING);
-    pub const EXECUTABLE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_EXECUTABLE);
-    pub const USEREXECUTABLE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USEREXECUTABLE);
-    pub const DATATYPEDEFINITION: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DATATYPEDEFINITION);
-    pub const ROLEPERMISSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ROLEPERMISSIONS);
-    pub const USERROLEPERMISSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERROLEPERMISSIONS);
-    pub const ACCESSRESTRICTIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSRESTRICTIONS);
-    pub const ACCESSLEVELEX: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVELEX);
+crate::enum_variants!(
+    AttributeId,
+    UA_AttributeId,
+    [
+        NODEID,
+        NODECLASS,
+        BROWSENAME,
+        DISPLAYNAME,
+        DESCRIPTION,
+        WRITEMASK,
+        USERWRITEMASK,
+        ISABSTRACT,
+        SYMMETRIC,
+        INVERSENAME,
+        CONTAINSNOLOOPS,
+        EVENTNOTIFIER,
+        VALUE,
+        DATATYPE,
+        VALUERANK,
+        ARRAYDIMENSIONS,
+        ACCESSLEVEL,
+        USERACCESSLEVEL,
+        MINIMUMSAMPLINGINTERVAL,
+        HISTORIZING,
+        EXECUTABLE,
+        USEREXECUTABLE,
+        DATATYPEDEFINITION,
+        ROLEPERMISSIONS,
+        USERROLEPERMISSIONS,
+        ACCESSRESTRICTIONS,
+        ACCESSLEVELEX,
+    ]
+);
 
+impl AttributeId {
     #[deprecated(note = "use `Self::VALUE` instead")]
     #[must_use]
     pub const fn value() -> Self {
@@ -50,41 +55,5 @@ impl AttributeId {
 impl hash::Hash for AttributeId {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
-    }
-}
-
-impl fmt::Display for AttributeId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let str = match self.0 {
-            UA_AttributeId::UA_ATTRIBUTEID_NODEID => "NODEID",
-            UA_AttributeId::UA_ATTRIBUTEID_NODECLASS => "NODECLASS",
-            UA_AttributeId::UA_ATTRIBUTEID_BROWSENAME => "BROWSENAME",
-            UA_AttributeId::UA_ATTRIBUTEID_DISPLAYNAME => "DISPLAYNAME",
-            UA_AttributeId::UA_ATTRIBUTEID_DESCRIPTION => "DESCRIPTION",
-            UA_AttributeId::UA_ATTRIBUTEID_WRITEMASK => "WRITEMASK",
-            UA_AttributeId::UA_ATTRIBUTEID_USERWRITEMASK => "USERWRITEMASK",
-            UA_AttributeId::UA_ATTRIBUTEID_ISABSTRACT => "ISABSTRACT",
-            UA_AttributeId::UA_ATTRIBUTEID_SYMMETRIC => "SYMMETRIC",
-            UA_AttributeId::UA_ATTRIBUTEID_INVERSENAME => "INVERSENAME",
-            UA_AttributeId::UA_ATTRIBUTEID_CONTAINSNOLOOPS => "CONTAINSNOLOOPS",
-            UA_AttributeId::UA_ATTRIBUTEID_EVENTNOTIFIER => "EVENTNOTIFIER",
-            UA_AttributeId::UA_ATTRIBUTEID_VALUE => "VALUE",
-            UA_AttributeId::UA_ATTRIBUTEID_DATATYPE => "DATATYPE",
-            UA_AttributeId::UA_ATTRIBUTEID_VALUERANK => "VALUERANK",
-            UA_AttributeId::UA_ATTRIBUTEID_ARRAYDIMENSIONS => "ARRAYDIMENSIONS",
-            UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVEL => "ACCESSLEVEL",
-            UA_AttributeId::UA_ATTRIBUTEID_USERACCESSLEVEL => "USERACCESSLEVEL",
-            UA_AttributeId::UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL => "MINIMUMSAMPLINGINTERVAL",
-            UA_AttributeId::UA_ATTRIBUTEID_HISTORIZING => "HISTORIZING",
-            UA_AttributeId::UA_ATTRIBUTEID_EXECUTABLE => "EXECUTABLE",
-            UA_AttributeId::UA_ATTRIBUTEID_USEREXECUTABLE => "USEREXECUTABLE",
-            UA_AttributeId::UA_ATTRIBUTEID_DATATYPEDEFINITION => "DATATYPEDEFINITION",
-            UA_AttributeId::UA_ATTRIBUTEID_ROLEPERMISSIONS => "ROLEPERMISSIONS",
-            UA_AttributeId::UA_ATTRIBUTEID_USERROLEPERMISSIONS => "USERROLEPERMISSIONS",
-            UA_AttributeId::UA_ATTRIBUTEID_ACCESSRESTRICTIONS => "ACCESSRESTRICTIONS",
-            UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVELEX => "ACCESSLEVELEX",
-            _ => return write!(f, "{}", self.as_u32()),
-        };
-        f.write_str(str)
     }
 }

--- a/src/ua/data_types/attribute_id.rs
+++ b/src/ua/data_types/attribute_id.rs
@@ -1,8 +1,40 @@
+use std::{fmt, hash};
+
 use open62541_sys::UA_AttributeId;
 
 crate::data_type!(AttributeId, UInt32);
 
 impl AttributeId {
+    pub const NODEID: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_NODEID);
+    pub const NODECLASS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_NODECLASS);
+    pub const BROWSENAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_BROWSENAME);
+    pub const DISPLAYNAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DISPLAYNAME);
+    pub const DESCRIPTION: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DESCRIPTION);
+    pub const WRITEMASK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_WRITEMASK);
+    pub const USERWRITEMASK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERWRITEMASK);
+    pub const ISABSTRACT: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ISABSTRACT);
+    pub const SYMMETRIC: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_SYMMETRIC);
+    pub const INVERSENAME: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_INVERSENAME);
+    pub const CONTAINSNOLOOPS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_CONTAINSNOLOOPS);
+    pub const EVENTNOTIFIER: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_EVENTNOTIFIER);
+    pub const VALUE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_VALUE);
+    pub const DATATYPE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DATATYPE);
+    pub const VALUERANK: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_VALUERANK);
+    pub const ARRAYDIMENSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ARRAYDIMENSIONS);
+    pub const ACCESSLEVEL: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVEL);
+    pub const USERACCESSLEVEL: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERACCESSLEVEL);
+    pub const MINIMUMSAMPLINGINTERVAL: Self =
+        Self(UA_AttributeId::UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL);
+    pub const HISTORIZING: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_HISTORIZING);
+    pub const EXECUTABLE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_EXECUTABLE);
+    pub const USEREXECUTABLE: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USEREXECUTABLE);
+    pub const DATATYPEDEFINITION: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_DATATYPEDEFINITION);
+    pub const ROLEPERMISSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ROLEPERMISSIONS);
+    pub const USERROLEPERMISSIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_USERROLEPERMISSIONS);
+    pub const ACCESSRESTRICTIONS: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSRESTRICTIONS);
+    pub const ACCESSLEVELEX: Self = Self(UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVELEX);
+
+    #[deprecated(note = "use `Self::VALUE` instead")]
     #[must_use]
     pub const fn value() -> Self {
         Self(UA_AttributeId::UA_ATTRIBUTEID_VALUE)
@@ -12,5 +44,47 @@ impl AttributeId {
         // This cast is necessary on Windows builds with inner type `i32`.
         #[allow(clippy::useless_conversion)]
         u32::try_from((self.0).0).expect("should convert to u32")
+    }
+}
+
+impl hash::Hash for AttributeId {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl fmt::Display for AttributeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match self.0 {
+            UA_AttributeId::UA_ATTRIBUTEID_NODEID => "NODEID",
+            UA_AttributeId::UA_ATTRIBUTEID_NODECLASS => "NODECLASS",
+            UA_AttributeId::UA_ATTRIBUTEID_BROWSENAME => "BROWSENAME",
+            UA_AttributeId::UA_ATTRIBUTEID_DISPLAYNAME => "DISPLAYNAME",
+            UA_AttributeId::UA_ATTRIBUTEID_DESCRIPTION => "DESCRIPTION",
+            UA_AttributeId::UA_ATTRIBUTEID_WRITEMASK => "WRITEMASK",
+            UA_AttributeId::UA_ATTRIBUTEID_USERWRITEMASK => "USERWRITEMASK",
+            UA_AttributeId::UA_ATTRIBUTEID_ISABSTRACT => "ISABSTRACT",
+            UA_AttributeId::UA_ATTRIBUTEID_SYMMETRIC => "SYMMETRIC",
+            UA_AttributeId::UA_ATTRIBUTEID_INVERSENAME => "INVERSENAME",
+            UA_AttributeId::UA_ATTRIBUTEID_CONTAINSNOLOOPS => "CONTAINSNOLOOPS",
+            UA_AttributeId::UA_ATTRIBUTEID_EVENTNOTIFIER => "EVENTNOTIFIER",
+            UA_AttributeId::UA_ATTRIBUTEID_VALUE => "VALUE",
+            UA_AttributeId::UA_ATTRIBUTEID_DATATYPE => "DATATYPE",
+            UA_AttributeId::UA_ATTRIBUTEID_VALUERANK => "VALUERANK",
+            UA_AttributeId::UA_ATTRIBUTEID_ARRAYDIMENSIONS => "ARRAYDIMENSIONS",
+            UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVEL => "ACCESSLEVEL",
+            UA_AttributeId::UA_ATTRIBUTEID_USERACCESSLEVEL => "USERACCESSLEVEL",
+            UA_AttributeId::UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL => "MINIMUMSAMPLINGINTERVAL",
+            UA_AttributeId::UA_ATTRIBUTEID_HISTORIZING => "HISTORIZING",
+            UA_AttributeId::UA_ATTRIBUTEID_EXECUTABLE => "EXECUTABLE",
+            UA_AttributeId::UA_ATTRIBUTEID_USEREXECUTABLE => "USEREXECUTABLE",
+            UA_AttributeId::UA_ATTRIBUTEID_DATATYPEDEFINITION => "DATATYPEDEFINITION",
+            UA_AttributeId::UA_ATTRIBUTEID_ROLEPERMISSIONS => "ROLEPERMISSIONS",
+            UA_AttributeId::UA_ATTRIBUTEID_USERROLEPERMISSIONS => "USERROLEPERMISSIONS",
+            UA_AttributeId::UA_ATTRIBUTEID_ACCESSRESTRICTIONS => "ACCESSRESTRICTIONS",
+            UA_AttributeId::UA_ATTRIBUTEID_ACCESSLEVELEX => "ACCESSLEVELEX",
+            _ => return write!(f, "{}", self.as_u32()),
+        };
+        f.write_str(str)
     }
 }


### PR DESCRIPTION
## Description

This provides read access to attribute nodes. It also introduces associated constants such as `ua::AttributeId::VALUE` that match the names from `open62541_sys` more closely (previously we had `ua::AttributeId::value()` for that).