### PR TITLE
Include predefined variants for NodeClass enum data type

### DIFF
--- a/src/ua/data_types/node_class.rs
+++ b/src/ua/data_types/node_class.rs
@@ -1,1 +1,17 @@
 crate::data_type!(NodeClass);
+
+crate::enum_variants!(
+    NodeClass,
+    UA_NodeClass,
+    [
+        UNSPECIFIED,
+        OBJECT,
+        VARIABLE,
+        METHOD,
+        OBJECTTYPE,
+        VARIABLETYPE,
+        REFERENCETYPE,
+        DATATYPE,
+        VIEW,
+    ],
+);


### PR DESCRIPTION
## Description

This adds the known variants to the wrapped `ua::NodeClass` enum data type.