### PR TITLE
Add support for continuation points when browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Allow reading node attributes with `AsyncClient::read_attribute()`
+- Allow continuing browsing from continuation points with `AsyncClient::browse_next()`
 
 ### Changed
 
 - Provide uppercase variants for enum data types, e.g. `ua::AttributedId::VALUE`. This deprecates
   the associated functions such as `ua::AttributedId::value()` formerly used for this purpose.
 - Rename `ua::String::as_slice()` to `as_bytes()`. Deprecate the former method.
+- Breaking: Return continuation points from `AsyncClient::browse()` and `browse_many()` (when not
+  all references were returned, to be used with `AsyncClient::browse_next()`)
 
 ## [0.4.0] - 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Provide uppercase variants for enum data types, e.g. `ua::AttributedId::VALUE`. This deprecates
   the associated functions such as `ua::AttributedId::value()` formerly used for this purpose.
+- Rename `ua::String::as_slice()` to `as_bytes()`. Deprecate the former method.
 
 ## [0.4.0] - 2024-02-12
 

--- a/examples/async_browse.rs
+++ b/examples/async_browse.rs
@@ -66,7 +66,7 @@ async fn browse_hierarchy(
                 Entry::Vacant(entry) => entry.insert(Vec::new()),
             };
 
-            let Some(references) = result else {
+            let Some((references, _)) = result else {
                 continue;
             };
 

--- a/examples/async_browse.rs
+++ b/examples/async_browse.rs
@@ -66,7 +66,8 @@ async fn browse_hierarchy(
                 Entry::Vacant(entry) => entry.insert(Vec::new()),
             };
 
-            let Some((references, _)) = result else {
+            // TODO: Use continuation point to fetch remaining references if necessary.
+            let Some((references, _continuation_point)) = result else {
                 continue;
             };
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -219,7 +219,7 @@ impl AsyncClient {
             return Ok(None);
         };
 
-        Ok(Some(output_arguments.as_slice().to_vec()))
+        Ok(Some(output_arguments.into_vec()))
     }
 
     /// Browses specific node.
@@ -248,7 +248,7 @@ impl AsyncClient {
             return Err(Error::internal("browse should return references"));
         };
 
-        Ok((references.as_slice().to_vec(), result.continuation_point()))
+        Ok((references.into_vec(), result.continuation_point()))
     }
 
     /// Browses several nodes at once.
@@ -286,7 +286,7 @@ impl AsyncClient {
             .map(|result| {
                 result
                     .references()
-                    .map(|references| (references.as_slice().to_vec(), result.continuation_point()))
+                    .map(|references| (references.into_vec(), result.continuation_point()))
             })
             .collect();
 
@@ -329,7 +329,7 @@ impl AsyncClient {
             .map(|result| {
                 result
                     .references()
-                    .map(|references| (references.as_slice().to_vec(), result.continuation_point()))
+                    .map(|references| (references.into_vec(), result.continuation_point()))
             })
             .collect();
 

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -2,6 +2,7 @@
 
 mod array;
 mod client;
+mod continuation_point;
 mod data_types;
 mod monitored_item_id;
 mod node_class_mask;
@@ -13,6 +14,7 @@ mod values;
 pub use self::{
     array::Array,
     client::{Client, ClientState},
+    continuation_point::ContinuationPoint,
     data_types::*,
     monitored_item_id::MonitoredItemId,
     node_class_mask::NodeClassMask,

--- a/src/ua/continuation_point.rs
+++ b/src/ua/continuation_point.rs
@@ -1,0 +1,25 @@
+use crate::ua;
+
+/// Wrapper for continuation point from [`open62541_sys`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContinuationPoint(ua::ByteString);
+
+impl ContinuationPoint {
+    #[must_use]
+    pub(crate) fn new(continuation_point: &ua::ByteString) -> Option<Self> {
+        // Unset continuation points indicate that the `BrowseResult` contains all references and no
+        // continuation is actually necessary.
+        if continuation_point.is_invalid() {
+            return None;
+        }
+
+        // The continuation point should not be an empty string.
+        debug_assert!(!continuation_point.is_empty());
+
+        Some(Self(continuation_point.clone()))
+    }
+
+    pub(crate) fn to_byte_string(&self) -> ua::ByteString {
+        self.0.clone()
+    }
+}

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -7,6 +7,7 @@ mod browse_request;
 mod browse_response;
 mod browse_result;
 mod browse_result_mask;
+mod byte_string;
 mod call_method_request;
 mod call_method_result;
 mod call_request;
@@ -45,8 +46,9 @@ pub use self::{
     attribute_id::AttributeId, browse_description::BrowseDescription,
     browse_direction::BrowseDirection, browse_request::BrowseRequest,
     browse_response::BrowseResponse, browse_result::BrowseResult,
-    browse_result_mask::BrowseResultMask, call_method_request::CallMethodRequest,
-    call_method_result::CallMethodResult, call_request::CallRequest, call_response::CallResponse,
+    browse_result_mask::BrowseResultMask, byte_string::ByteString,
+    call_method_request::CallMethodRequest, call_method_result::CallMethodResult,
+    call_request::CallRequest, call_response::CallResponse,
     create_monitored_items_request::CreateMonitoredItemsRequest,
     create_monitored_items_response::CreateMonitoredItemsResponse,
     create_subscription_request::CreateSubscriptionRequest,

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -3,6 +3,8 @@
 mod attribute_id;
 mod browse_description;
 mod browse_direction;
+mod browse_next_request;
+mod browse_next_response;
 mod browse_request;
 mod browse_response;
 mod browse_result;
@@ -44,7 +46,8 @@ mod write_value;
 
 pub use self::{
     attribute_id::AttributeId, browse_description::BrowseDescription,
-    browse_direction::BrowseDirection, browse_request::BrowseRequest,
+    browse_direction::BrowseDirection, browse_next_request::BrowseNextRequest,
+    browse_next_response::BrowseNextResponse, browse_request::BrowseRequest,
     browse_response::BrowseResponse, browse_result::BrowseResult,
     browse_result_mask::BrowseResultMask, byte_string::ByteString,
     call_method_request::CallMethodRequest, call_method_result::CallMethodResult,

--- a/src/ua/data_types/browse_next_request.rs
+++ b/src/ua/data_types/browse_next_request.rs
@@ -1,0 +1,26 @@
+use crate::{ua, ServiceRequest};
+
+crate::data_type!(BrowseNextRequest);
+
+impl BrowseNextRequest {
+    #[must_use]
+    pub fn with_continuation_points(
+        mut self,
+        continuation_points: &[ua::ContinuationPoint],
+    ) -> Self {
+        let array = ua::Array::from_iter(
+            continuation_points
+                .iter()
+                .map(ua::ContinuationPoint::to_byte_string),
+        );
+        array.move_into_raw(
+            &mut self.0.continuationPointsSize,
+            &mut self.0.continuationPoints,
+        );
+        self
+    }
+}
+
+impl ServiceRequest for BrowseNextRequest {
+    type Response = ua::BrowseNextResponse;
+}

--- a/src/ua/data_types/browse_next_response.rs
+++ b/src/ua/data_types/browse_next_response.rs
@@ -1,0 +1,19 @@
+use crate::{ua, ServiceResponse};
+
+crate::data_type!(BrowseNextResponse);
+
+impl BrowseNextResponse {
+    #[must_use]
+    pub fn results(&self) -> Option<ua::Array<ua::BrowseResult>> {
+        // TODO: Adjust signature to return non-owned value instead.
+        ua::Array::from_raw_parts(self.0.results, self.0.resultsSize)
+    }
+}
+
+impl ServiceResponse for BrowseNextResponse {
+    type Request = ua::BrowseNextRequest;
+
+    fn service_result(&self) -> ua::StatusCode {
+        ua::StatusCode::new(self.0.responseHeader.serviceResult)
+    }
+}

--- a/src/ua/data_types/browse_result.rs
+++ b/src/ua/data_types/browse_result.rs
@@ -8,4 +8,15 @@ impl BrowseResult {
         // TODO: Adjust signature to return non-owned value instead.
         ua::Array::from_raw_parts(self.0.references, self.0.referencesSize)
     }
+
+    /// Gets continuation point.
+    ///
+    /// Browse results include a continuation point when not all references could be returned. Pass
+    /// it to [`AsyncClient::browse_next()`] to request the remaining references.
+    ///
+    /// [`AsyncClient::browse_next()`]: crate::AsyncClient::browse_next
+    #[must_use]
+    pub fn continuation_point(&self) -> Option<ua::ContinuationPoint> {
+        ua::ContinuationPoint::new(ua::ByteString::raw_ref(&self.0.continuationPoint))
+    }
 }

--- a/src/ua/data_types/browse_result.rs
+++ b/src/ua/data_types/browse_result.rs
@@ -1,4 +1,4 @@
-use crate::ua;
+use crate::{ua, DataType as _};
 
 crate::data_type!(BrowseResult);
 

--- a/src/ua/data_types/byte_string.rs
+++ b/src/ua/data_types/byte_string.rs
@@ -1,0 +1,51 @@
+use std::slice;
+
+use crate::ua;
+
+// Technically, `open62541_sys::ByteString` is an alias for `open62541_sys::String`. But we treat it
+// as a distinct type to improve type safety. The difference is that `String` contains valid Unicode
+// whereas `ByteString` may contain arbitrary byte sequences.
+crate::data_type!(ByteString);
+
+// In the implementation below, remember that `self.0.data` may be `UA_EMPTY_ARRAY_SENTINEL` for any
+// strings of `length` 0. It may also be `ptr::null()` for "invalid" strings. This is similar to how
+// OPC UA treats arrays (which also distinguishes between empty and invalid instances).
+impl ByteString {
+    /// Checks if byte string is invalid.
+    ///
+    /// The invalid state is defined by OPC UA. It is a third state which is distinct from empty and
+    /// regular (non-empty) byte strings.
+    #[must_use]
+    pub fn is_invalid(&self) -> bool {
+        matches!(self.array_value(), ua::ArrayValue::Invalid)
+    }
+
+    /// Checks if byte string is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        matches!(self.array_value(), ua::ArrayValue::Empty)
+    }
+
+    /// Returns byte string contents as slice.
+    ///
+    /// This may return [`None`] when the byte string itself is invalid (as defined by OPC UA).
+    #[must_use]
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        // Internally, `open62541` represents strings as `Byte` array and has the same special cases
+        // as regular arrays, i.e. empty and invalid states.
+        match self.array_value() {
+            ua::ArrayValue::Invalid => None,
+            ua::ArrayValue::Empty => Some(&[]),
+            ua::ArrayValue::Valid(data) => {
+                // `self.0.data` is valid, so we may use `self.0.length` now.
+                Some(unsafe { slice::from_raw_parts(data.as_ptr(), self.0.length) })
+            }
+        }
+    }
+
+    fn array_value(&self) -> ua::ArrayValue<u8> {
+        // Internally, `open62541` represents strings as `Byte` array and has the same special cases
+        // as regular arrays, i.e. empty and invalid states.
+        ua::ArrayValue::from_ptr(self.0.data)
+    }
+}

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -10,6 +10,21 @@ crate::data_type!(String);
 // strings of `length` 0. It may also be `ptr::null()` for "invalid" strings. This is similar to how
 // OPC UA treats arrays (which also distinguishes between empty and invalid instances).
 impl String {
+    /// Checks if string is invalid.
+    ///
+    /// The invalid state is defined by OPC UA. It is a third state which is distinct from empty and
+    /// regular (non-empty) strings.
+    #[must_use]
+    pub fn is_invalid(&self) -> bool {
+        matches!(self.array_value(), ua::ArrayValue::Invalid)
+    }
+
+    /// Checks if string is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        matches!(self.array_value(), ua::ArrayValue::Empty)
+    }
+
     #[deprecated(note = "use `Self::as_bytes()` instead")]
     #[must_use]
     pub fn as_slice(&self) -> Option<&[u8]> {
@@ -23,7 +38,7 @@ impl String {
     pub fn as_bytes(&self) -> Option<&[u8]> {
         // Internally, `open62541` represents strings as `Byte` array and has the same special cases
         // as regular arrays, i.e. empty and invalid states.
-        match ua::ArrayValue::from_ptr(self.0.data) {
+        match self.array_value() {
             ua::ArrayValue::Invalid => None,
             ua::ArrayValue::Empty => Some(&[]),
             ua::ArrayValue::Valid(data) => {
@@ -35,11 +50,17 @@ impl String {
 
     /// Returns string contents as string slice.
     ///
-    /// This may return [`None`] when the string itself is invalid (as defined by OPC UA) or it is
-    /// not valid UTF-8.
+    /// This may return [`None`] when the string itself is invalid (as defined by OPC UA) or when it
+    /// is not valid Unicode (UTF-8).
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
         self.as_bytes().and_then(|slice| str::from_utf8(slice).ok())
+    }
+
+    fn array_value(&self) -> ua::ArrayValue<u8> {
+        // Internally, `open62541` represents strings as `Byte` array and has the same special cases
+        // as regular arrays, i.e. empty and invalid states.
+        ua::ArrayValue::from_ptr(self.0.data)
     }
 }
 

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -10,11 +10,17 @@ crate::data_type!(String);
 // strings of `length` 0. It may also be `ptr::null()` for "invalid" strings. This is similar to how
 // OPC UA treats arrays (which also distinguishes between empty and invalid instances).
 impl String {
+    #[deprecated(note = "use `Self::as_bytes()` instead")]
+    #[must_use]
+    pub fn as_slice(&self) -> Option<&[u8]> {
+        self.as_bytes()
+    }
+
     /// Returns string contents as byte slice.
     ///
     /// This may return [`None`] when the string itself is invalid (as defined by OPC UA).
     #[must_use]
-    pub fn as_slice(&self) -> Option<&[u8]> {
+    pub fn as_bytes(&self) -> Option<&[u8]> {
         // Internally, `open62541` represents strings as `Byte` array and has the same special cases
         // as regular arrays, i.e. empty and invalid states.
         match ua::ArrayValue::from_ptr(self.0.data) {
@@ -33,7 +39,7 @@ impl String {
     /// not valid UTF-8.
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
-        self.as_slice().and_then(|slice| str::from_utf8(slice).ok())
+        self.as_bytes().and_then(|slice| str::from_utf8(slice).ok())
     }
 }
 


### PR DESCRIPTION
## Description

OPC UA servers may decide to not return all references when browsing nodes. This is indicated by continuation points. In this PR, we add support for this by returning `Option<ContinuationPoint>` from `AsyncClient::browse()`/`browse_many()`. These can later be used with `AsynClient::browse_next()` to retrieve the remaining references (or another continuation point).