### PR TITLE
Return inner errors from browse_many()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Breaking: Return `Result` instead of `Option` for references in `AsyncClient::browse_many()` and
+  `browse_next()` (#59).
+
+### Fixed
+
+- Return browsing error instead of empty references list from `AsyncClient::browse()`.
+
 ## [0.5.0] - 2024-03-01
 
 [0.5.0]: https://github.com/HMIProject/open62541/compare/v0.4.0...v0.5.0
 
 ### Added
 
-- Allow reading node attributes with ``AsyncClient::read_attribute()` and `read_attributes()`
-- Allow continuing browsing from continuation points with `AsyncClient::browse_next()`
+- Allow reading node attributes with ``AsyncClient::read_attribute()` and `read_attributes()`.
+- Allow continuing browsing from continuation points with `AsyncClient::browse_next()`.
 
 ### Changed
 
 - Provide uppercase variants for enum data types, e.g. `ua::AttributedId::VALUE`. This deprecates
   the associated functions such as `ua::AttributedId::value()` formerly used for this purpose.
 - Breaking: Return continuation points from `AsyncClient::browse()` and `browse_many()` (when not
-  all references were returned, to be used with `AsyncClient::browse_next()`)
+  all references were returned, to be used with `AsyncClient::browse_next()`).
 - Breaking: Simplify argument type `node_ids: &[impl Borrow<ua::NodeId>]` to `&[ua::NodeId]` in
-  `AsyncClient::browse_many()`
+  `AsyncClient::browse_many()`.
 - Rename `ua::String::as_slice()` to `as_bytes()`. Deprecate the former method.
 
 ## [0.4.0] - 2024-02-12

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -73,6 +73,20 @@ impl AsyncClient {
         Ok(client.state())
     }
 
+    /// Reads node value.
+    ///
+    /// To read other attributes, see [`read_attribute()`] and [`read_attributes()`].
+    ///
+    /// # Errors
+    ///
+    /// This fails when the node does not exist or its value attribute cannot be read.
+    ///
+    /// [`read_attribute()`]: Self::read_attribute
+    /// [`read_attributes()`]: Self::read_attributes
+    pub async fn read_value(&self, node_id: &ua::NodeId) -> Result<ua::DataValue, Error> {
+        self.read_attribute(node_id, &ua::AttributeId::VALUE).await
+    }
+
     /// Reads node attribute.
     ///
     /// To read only the value attribute, you can also use [`read_value()`].
@@ -100,20 +114,6 @@ impl AsyncClient {
             .next()
             .expect("should contain exactly one attribute");
         Ok(value)
-    }
-
-    /// Reads node value.
-    ///
-    /// To read other attributes, see [`read_attribute()`] and [`read_attributes()`].
-    ///
-    /// # Errors
-    ///
-    /// This fails when the node does not exist or its value attribute cannot be read.
-    ///
-    /// [`read_attribute()`]: Self::read_attribute
-    /// [`read_attributes()`]: Self::read_attributes
-    pub async fn read_value(&self, node_id: &ua::NodeId) -> Result<ua::DataValue, Error> {
-        self.read_attribute(node_id, &ua::AttributeId::VALUE).await
     }
 
     /// Reads several node attributes.

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use open62541_sys::{
     UA_Client_connect, UA_Client_getConfig, UA_LogCategory, UA_LogLevel, UA_STATUSCODE_GOOD,
 };
 
-use crate::{ua, Error};
+use crate::{ua, Error, Result};
 
 /// Builder for [`Client`].
 ///
@@ -77,7 +77,7 @@ impl ClientBuilder {
     /// # Panics
     ///
     /// The endpoint URL must not contain any NUL bytes.
-    pub fn connect(mut self, endpoint_url: &str) -> Result<Client, Error> {
+    pub fn connect(mut self, endpoint_url: &str) -> Result<Client> {
         log::info!("Connecting to endpoint {endpoint_url}");
 
         let endpoint_url =
@@ -140,7 +140,7 @@ impl Client {
     /// # Panics
     ///
     /// See [`ClientBuilder::connect()`].
-    pub fn new(endpoint_url: &str) -> Result<Self, Error> {
+    pub fn new(endpoint_url: &str) -> Result<Self> {
         ClientBuilder::default().connect(endpoint_url)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,10 @@ use thiserror::Error;
 
 use crate::ua;
 
-/// Generic error.
+/// Result type used in this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error type used in this crate.
 ///
 /// This error may be returned from many different OPC UA calls. It represents any status code other
 /// than [`UA_STATUSCODE_GOOD`].
@@ -25,7 +28,7 @@ impl Error {
         Self::Server(status_code)
     }
 
-    pub(crate) fn verify_good(status_code: &ua::StatusCode) -> Result<(), Self> {
+    pub(crate) fn verify_good(status_code: &ua::StatusCode) -> Result<()> {
         if status_code.is_good() {
             Ok(())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod callback;
 pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
-    error::Error,
+    error::{Error, Result},
 };
 pub(crate) use self::{
     data_type::{data_type, enum_variants},

--- a/src/ua/data_types/browse_result.rs
+++ b/src/ua/data_types/browse_result.rs
@@ -4,6 +4,11 @@ crate::data_type!(BrowseResult);
 
 impl BrowseResult {
     #[must_use]
+    pub const fn status_code(&self) -> ua::StatusCode {
+        ua::StatusCode::new(self.0.statusCode)
+    }
+
+    #[must_use]
     pub fn references(&self) -> Option<ua::Array<ua::ReferenceDescription>> {
         // TODO: Adjust signature to return non-owned value instead.
         ua::Array::from_raw_parts(self.0.references, self.0.referencesSize)

--- a/src/ua/data_types/date_time.rs
+++ b/src/ua/data_types/date_time.rs
@@ -1,3 +1,5 @@
+use crate::Error;
+
 crate::data_type!(DateTime);
 
 impl DateTime {
@@ -18,7 +20,7 @@ impl DateTime {
 
 #[cfg(feature = "time")]
 impl TryFrom<time::OffsetDateTime> for DateTime {
-    type Error = crate::Error;
+    type Error = Error;
 
     /// Creates [`DateTime`] from [`time::OffsetDateTime`].
     ///
@@ -44,7 +46,7 @@ impl TryFrom<time::OffsetDateTime> for DateTime {
         let ticks_ua = ticks_unix + i128::from(UA_DATETIME_UNIX_EPOCH);
 
         i64::try_from(ticks_ua)
-            .map_err(|_| crate::Error::internal("DateTime should be in range"))
+            .map_err(|_| Error::internal("DateTime should be in range"))
             .map(Self)
     }
 }

--- a/src/ua/data_types/date_time.rs
+++ b/src/ua/data_types/date_time.rs
@@ -1,5 +1,3 @@
-use crate::Error;
-
 crate::data_type!(DateTime);
 
 impl DateTime {
@@ -20,7 +18,8 @@ impl DateTime {
 
 #[cfg(feature = "time")]
 impl TryFrom<time::OffsetDateTime> for DateTime {
-    type Error = Error;
+    // Explicit module path to avoid linter errors when feature is not enable by `#[cfg()]`.
+    type Error = crate::Error;
 
     /// Creates [`DateTime`] from [`time::OffsetDateTime`].
     ///
@@ -46,7 +45,8 @@ impl TryFrom<time::OffsetDateTime> for DateTime {
         let ticks_ua = ticks_unix + i128::from(UA_DATETIME_UNIX_EPOCH);
 
         i64::try_from(ticks_ua)
-            .map_err(|_| Error::internal("DateTime should be in range"))
+            // Explicit module path to avoid linter errors when feature is not enable by `#[cfg()]`.
+            .map_err(|_| crate::Error::internal("DateTime should be in range"))
             .map(Self)
     }
 }


### PR DESCRIPTION
## Description

This PR adjusts the return type of `AsyncClient::browse_many()`, `browse_next()` to return `Result` instead of `Option`. We also add handling of browsing errors in the first place: up til now, we would have returned an empty list of references instead.