### PR TITLE
Fix hardcoded node IDs in examples after server update

### DIFF
--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -10,12 +10,12 @@ async fn main() -> anyhow::Result<()> {
     let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
         .context("connect")?;
 
-    // `/Root/Objects/8:Simulation/8:ObjectWithMethods`
-    let object_node_id = ua::NodeId::string(8, "ObjectWithMethods");
-    // `/Root/Objects/8:Simulation/8:ObjectWithMethods/8:MethodNoArgs`
-    let method_no_args_node_id = ua::NodeId::string(8, "MethodNoArgs");
-    // `/Root/Objects/8:Simulation/8:ObjectWithMethods/8:MethodIO`
-    let method_io_node_id = ua::NodeId::string(8, "MethodIO");
+    // `/Root/Objects/9:Simulation/9:ObjectWithMethods`
+    let object_node_id = ua::NodeId::string(9, "ObjectWithMethods");
+    // `/Root/Objects/9:Simulation/9:ObjectWithMethods/9:MethodNoArgs`
+    let method_no_args_node_id = ua::NodeId::string(9, "MethodNoArgs");
+    // `/Root/Objects/9:Simulation/9:ObjectWithMethods/9:MethodIO`
+    let method_io_node_id = ua::NodeId::string(9, "MethodIO");
 
     println!("Calling node {method_no_args_node_id}");
 

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -30,8 +30,8 @@ async fn main() -> anyhow::Result<()> {
             .context("create first subscription")?,
     );
 
-    // `/Root/Objects/1:Boiler#1/1:CustomController/1:Input1`
-    let input_node_id = ua::NodeId::numeric(1, 1773);
+    // `/Root/Objects/2:DeviceSet/1:CoffeeMachine/1:Espresso/7:BeverageSize`
+    let input_node_id = ua::NodeId::numeric(1, 1074);
 
     // `/Root/Objects/Server/ServerStatus/CurrentTime`
     let current_time_node_id = ua::NodeId::numeric(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -25,8 +25,8 @@ async fn main() -> anyhow::Result<()> {
     let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
         .context("connect")?;
 
-    // `/Root/Objects/1:Boiler#1/1:CustomController/1:Input1`
-    let node_id = ua::NodeId::numeric(1, 1773);
+    // `/Root/Objects/2:DeviceSet/1:CoffeeMachine/1:Espresso/7:BeverageSize`
+    let node_id = ua::NodeId::numeric(1, 1074);
 
     println!("Reading node {node_id}");
 
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         .write_value(
             &node_id,
             &ua::DataValue::init()
-                .with_value(&ua::Variant::init().with_scalar(&ua::Double::new(value))),
+                .with_value(&ua::Variant::init().with_scalar(&ua::Float::new(value))),
         )
         .await
         .context("write")?;


### PR DESCRIPTION
## Description

This PR adjusts the node IDs we use on our examples after the server `opc.tcp://opcuademo.sterfive.com:26543` seems to have been updated with a different data hierarchy.