### PR TITLE
Introduce separate Userdata wrapper

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 
 use crate::Userdata;
 
-/// Type-removed one-shot callback.
+/// Type-erased one-shot callback.
 ///
 /// Use this to wrap an [`FnOnce`] closure into a data structure that may be passed via a [`c_void`]
 /// pointer as user data to an external library. Later, when this `extern` callback is run with that
@@ -72,7 +72,7 @@ impl<T> CallbackOnce<T> {
     }
 }
 
-/// Type-removed stream sender.
+/// Type-erased stream sender.
 ///
 /// Use this to wrap a [`Sender`] into a data structure that may be passed via a [`c_void`] pointer
 /// as user data to an external library. Later, when this `extern` callback is run with that data,

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -17,16 +17,16 @@ use tokio::sync::mpsc;
 ///
 /// ```
 /// use open62541::CallbackOnce;
-/// use std::{cell::RefCell, rc::Rc};
+/// use std::{cell::Cell, rc::Rc};
 /// # use std::ffi::c_void;
 ///
-/// let cell = Rc::new(RefCell::new(0));
+/// let cell = Rc::new(Cell::new(0));
 ///
 /// // Turn `tx` into type-erased void pointer for FFI.
 /// let raw_data: *mut c_void = CallbackOnce::<u32>::prepare({
 ///     let cell = Rc::clone(&cell);
 ///     move |value| {
-///         *cell.borrow_mut() = value;
+///         cell.set(value);
 ///     }
 /// });
 ///
@@ -35,7 +35,7 @@ use tokio::sync::mpsc;
 ///
 /// // Value has been received.
 ///
-/// assert_eq!(*cell.borrow(), 123);
+/// assert_eq!(cell.get(), 123);
 /// ```
 #[allow(clippy::module_name_repetitions)]
 pub struct CallbackOnce<T>(Box<dyn FnOnce(T)>);

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use std::{ffi::c_void, marker::PhantomData};
 
 use tokio::sync::mpsc;
 
@@ -39,7 +39,7 @@ use crate::Userdata;
 /// assert_eq!(cell.get(), 123);
 /// ```
 #[allow(clippy::module_name_repetitions)]
-pub struct CallbackOnce<T>(T);
+pub struct CallbackOnce<T>(PhantomData<T>);
 
 // TODO: Use inherent associated type to define this directly on `CallbackOnce`. At the moment, this
 // is not possible yet.
@@ -114,7 +114,7 @@ impl<T> CallbackOnce<T> {
 /// assert_eq!(block_on(rx.recv()), None);
 /// ```
 #[allow(clippy::module_name_repetitions)]
-pub struct CallbackStream<T>(T);
+pub struct CallbackStream<T>(PhantomData<T>);
 
 // TODO: Use inherent associated type to define this directly on `CallbackOnce`. At the moment, this
 // is not possible yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
     error::{Error, Result},
+    userdata::Userdata,
 };
 pub(crate) use self::{
     data_type::{data_type, enum_variants},
@@ -103,5 +104,4 @@ pub use self::{
     async_monitored_item::AsyncMonitoredItem,
     async_subscription::AsyncSubscription,
     callback::{CallbackOnce, CallbackStream},
-    userdata::Userdata,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ mod async_monitored_item;
 mod async_subscription;
 #[cfg(feature = "tokio")]
 mod callback;
+mod userdata;
 
 pub use self::{
     client::{Client, ClientBuilder},
@@ -102,4 +103,5 @@ pub use self::{
     async_monitored_item::AsyncMonitoredItem,
     async_subscription::AsyncSubscription,
     callback::{CallbackOnce, CallbackStream},
+    userdata::Userdata,
 };

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,0 +1,104 @@
+use std::ffi::c_void;
+
+/// Type-removed user data.
+///
+/// Use this to wrap arbitrary data into a structure which may be passed via a [`c_void`] pointer to
+/// an external library. Later, when this `extern` callback is run with that data, you may unwrap it
+/// and can thus access the original data.
+///
+/// The implementation uses associated methods:
+///
+/// - [`Userdata::prepare()`] to wrap the user data and get a [`c_void`] pointer
+/// - [`Userdata::peek_at()`] to unwrap the [`c_void`] pointer and get the user data
+/// - [`Userdata::consume()`] to clean up the [`c_void`] pointer and get the user data
+///
+/// Each [`prepare()`] must be paired with exactly one [`consume()`] to release the data held by the
+/// wrapper structure. [`peek_at()`] must only be called in-between and the lifetime of the returned
+/// reference is not allowed to extend past the next call to either [`peek_at()`] or [`consume()`].
+///
+/// [`prepare()`]: Self::prepare
+/// [`peek_at()`]: Self::peek_at
+/// [`consume()`]: Self::consume
+///
+/// # Examples
+///
+/// ```
+/// use open62541::Userdata;
+/// # use std::ffi::c_void;
+///
+/// // Turn user data into type-erased void pointer for FFI.
+/// let raw_data: *mut c_void = Userdata::<u32>::prepare(0);
+///
+/// // Use type-erased pointer to get/manipulate user data.
+/// unsafe {
+///     let userdata = Userdata::<u32>::peek_at(raw_data);
+///     assert_eq!(*userdata, 0);
+///     *userdata = 123;
+/// }
+///
+/// // Unwrap data. Clean up resources held by pointer.
+/// let userdata = unsafe {
+///     Userdata::<u32>::consume(raw_data)
+/// };
+///
+/// // Got user data. `raw_data` is no longer valid.
+/// assert_eq!(userdata, 123);
+/// ```
+pub struct Userdata<T>(T);
+
+impl<T> Userdata<T> {
+    /// Wraps user data.
+    ///
+    /// This allocates memory. To prevent memory leaks, ensure to call [`consume()`] on the returned
+    /// pointer exactly once.
+    ///
+    /// [`consume()`]: Self::consume
+    pub fn prepare(value: T) -> *mut c_void {
+        let userdata = Userdata(value);
+        // Move `userdata` onto the heap and leak its memory into a raw pointer. This region will be
+        // reclaimed later in `consume()`.
+        let ptr: *mut Userdata<T> = Box::into_raw(Box::new(userdata));
+        ptr.cast::<c_void>()
+    }
+
+    /// Unwraps [`c_void`] pointer to access data.
+    ///
+    /// # Safety
+    ///
+    /// The given pointer must have been returned from [`prepare()`], using the same value type `T`.
+    /// It must not have been given to [`consume()`] yet.
+    ///
+    /// The lifetime of the returned reference is not allowed to extend past the next call to either
+    /// [`peek_at()`] or [`consume()`].
+    ///
+    /// [`prepare()`]: Self::prepare
+    /// [`peek_at()`]: Self::peek_at
+    /// [`consume()`]: Self::consume
+    pub unsafe fn peek_at<'a>(data: *mut c_void) -> &'a mut T {
+        let ptr: *mut Userdata<T> = data.cast::<Userdata<T>>();
+        // Reconstruct heap-allocated `userdata` back into its `Box`.
+        let userdata = unsafe { Box::from_raw(ptr) };
+        // Leak box as we do not want to destroy the data yet. This happens only when `consume()` is
+        // called later.
+        &mut Box::leak(userdata).0
+    }
+
+    /// Unwraps [`c_void`] pointer and release memory.
+    ///
+    /// # Safety
+    ///
+    /// The given pointer must have been returned from [`prepare()`], using the same value type `T`.
+    /// It must not have been given to [`consume()`] yet.
+    ///
+    /// [`prepare()`]: Self::prepare
+    /// [`peek_at()`]: Self::peek_at
+    /// [`consume()`]: Self::consume
+    pub unsafe fn consume(data: *mut c_void) -> T {
+        let ptr: *mut Userdata<T> = data.cast::<Userdata<T>>();
+        // Reconstruct heap-allocated `userdata` back into its `Box`.
+        let userdata = unsafe { Box::from_raw(ptr) };
+        // TODO: Prefer `Box::into_inner()` when it becomes stable.
+        // https://github.com/rust-lang/rust/issues/80437
+        (*userdata).0
+    }
+}

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, marker::PhantomData};
 
-/// Type-removed user data.
+/// Type-erased user data.
 ///
 /// Use this to wrap arbitrary data into a structure which may be passed via a [`c_void`] pointer to
 /// an external library. Later, when this `extern` callback is run with that data, you may unwrap it


### PR DESCRIPTION
## Description

This PR extracts the heap-managed and type-erased pointer implementation used in `CallbackOnce` and `CallbackStream` into its own type `Userdata`.

This is part of a future refactor where we want to pass more information into FFI callbacks and need this flexibility.