### PR TITLE
Implement Debug for Array

### DIFF
--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_void, mem::MaybeUninit, ptr};
+use std::{ffi::c_void, fmt::Debug, mem::MaybeUninit, ptr};
 
 use open62541_sys::{
     UA_DataType, UA_Order, UA_clear, UA_copy, UA_init, UA_order, UA_print, UA_STATUSCODE_GOOD,
@@ -17,7 +17,7 @@ use open62541_sys::{
 /// they are regularly passed by value to functions in order to transfer ownership.
 ///
 /// [`Inner`]: DataType::Inner
-pub unsafe trait DataType: Clone {
+pub unsafe trait DataType: Debug + Clone {
     /// Inner type.
     ///
     /// It must be possible to transmute between the inner type and the type that implements

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::c_void,
-    mem,
+    fmt, mem,
     num::NonZeroUsize,
     ptr::{self, NonNull},
     slice,
@@ -324,12 +324,11 @@ impl<T: DataType> Drop for Array<T> {
 //     }
 // }
 
-// TODO
-// impl<T: DataType> fmt::Debug for Array<T> {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         todo!()
-//     }
-// }
+impl<T: DataType> fmt::Debug for Array<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.as_slice())
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description

This PR adds an implementation of `Debug` for our `Array` wrapper type. We also include `Debug` in our `DataType` trait to make downstream use easier (data types are always expected to implement `Debug`).