### PR TITLE
Add ExtensionObject and Argument data types

### DIFF
--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -1,5 +1,6 @@
 //! Thin wrappers for OPC UA data types from [`open62541_sys`].
 
+mod argument;
 mod attribute_id;
 mod browse_description;
 mod browse_direction;
@@ -25,6 +26,7 @@ mod delete_monitored_items_response;
 mod delete_subscriptions_request;
 mod delete_subscriptions_response;
 mod expanded_node_id;
+mod extension_object;
 mod localized_text;
 mod monitored_item_create_request;
 mod monitored_item_create_result;
@@ -45,7 +47,7 @@ mod write_response;
 mod write_value;
 
 pub use self::{
-    attribute_id::AttributeId, browse_description::BrowseDescription,
+    argument::Argument, attribute_id::AttributeId, browse_description::BrowseDescription,
     browse_direction::BrowseDirection, browse_next_request::BrowseNextRequest,
     browse_next_response::BrowseNextResponse, browse_request::BrowseRequest,
     browse_response::BrowseResponse, browse_result::BrowseResult,
@@ -60,7 +62,8 @@ pub use self::{
     delete_monitored_items_response::DeleteMonitoredItemsResponse,
     delete_subscriptions_request::DeleteSubscriptionsRequest,
     delete_subscriptions_response::DeleteSubscriptionsResponse, expanded_node_id::ExpandedNodeId,
-    localized_text::LocalizedText, monitored_item_create_request::MonitoredItemCreateRequest,
+    extension_object::ExtensionObject, localized_text::LocalizedText,
+    monitored_item_create_request::MonitoredItemCreateRequest,
     monitored_item_create_result::MonitoredItemCreateResult, node_class::NodeClass,
     node_id::NodeId, node_id_type::NodeIdType, qualified_name::QualifiedName,
     read_request::ReadRequest, read_response::ReadResponse, read_value_id::ReadValueId,

--- a/src/ua/data_types/argument.rs
+++ b/src/ua/data_types/argument.rs
@@ -1,0 +1,31 @@
+use crate::{ua, DataType};
+
+crate::data_type!(Argument);
+
+impl Argument {
+    #[must_use]
+    pub fn name(&self) -> &ua::String {
+        ua::String::raw_ref(&self.0.name)
+    }
+
+    #[must_use]
+    pub fn data_type(&self) -> &ua::NodeId {
+        ua::NodeId::raw_ref(&self.0.dataType)
+    }
+
+    #[must_use]
+    pub const fn value_rank(&self) -> i32 {
+        self.0.valueRank
+    }
+
+    #[must_use]
+    pub fn array_dimensions(&self) -> Option<ua::Array<ua::UInt32>> {
+        // TODO: Adjust signature to return non-owned value instead.
+        ua::Array::from_raw_parts(self.0.arrayDimensions, self.0.arrayDimensionsSize)
+    }
+
+    #[must_use]
+    pub fn description(&self) -> &ua::LocalizedText {
+        ua::LocalizedText::raw_ref(&self.0.description)
+    }
+}

--- a/src/ua/data_types/byte_string.rs
+++ b/src/ua/data_types/byte_string.rs
@@ -49,3 +49,15 @@ impl ByteString {
         ua::ArrayValue::from_ptr(self.0.data)
     }
 }
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ByteString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_bytes()
+            .ok_or(serde::ser::Error::custom("String should be valid"))
+            .and_then(|bytes| serializer.serialize_bytes(bytes))
+    }
+}

--- a/src/ua/data_types/expanded_node_id.rs
+++ b/src/ua/data_types/expanded_node_id.rs
@@ -14,7 +14,7 @@ impl ExpandedNodeId {
     }
 
     #[must_use]
-    pub fn server_index(&self) -> u32 {
+    pub const fn server_index(&self) -> u32 {
         self.0.serverIndex
     }
 }

--- a/src/ua/data_types/expanded_node_id.rs
+++ b/src/ua/data_types/expanded_node_id.rs
@@ -7,4 +7,14 @@ impl ExpandedNodeId {
     pub fn node_id(&self) -> &ua::NodeId {
         ua::NodeId::raw_ref(&self.0.nodeId)
     }
+
+    #[must_use]
+    pub fn namespace_uri(&self) -> &ua::String {
+        ua::String::raw_ref(&self.0.namespaceUri)
+    }
+
+    #[must_use]
+    pub fn server_index(&self) -> u32 {
+        self.0.serverIndex
+    }
 }

--- a/src/ua/data_types/extension_object.rs
+++ b/src/ua/data_types/extension_object.rs
@@ -6,6 +6,7 @@ crate::data_type!(ExtensionObject);
 
 impl ExtensionObject {
     /// Gets encoded byte string content.
+    #[must_use]
     pub fn encoded_content_bytestring(&self) -> Option<(&ua::NodeId, &ua::ByteString)> {
         match self.0.encoding {
             UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_ENCODED_BYTESTRING => {}
@@ -21,6 +22,7 @@ impl ExtensionObject {
     }
 
     /// Gets encoded XML content.
+    #[must_use]
     pub fn encoded_content_xml(&self) -> Option<(&ua::NodeId, &ua::String)> {
         match self.0.encoding {
             UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_ENCODED_XML => {}
@@ -36,6 +38,7 @@ impl ExtensionObject {
     }
 
     /// Gets decoded content.
+    #[must_use]
     pub fn decoded_content<T: DataType>(&self) -> Option<&T> {
         match self.0.encoding {
             UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_DECODED
@@ -45,11 +48,10 @@ impl ExtensionObject {
 
         let decoded_content = unsafe { self.0.content.decoded.as_ref() };
 
-        (decoded_content.type_ == T::data_type()).then(|| {
-            T::raw_ref(
-                unsafe { decoded_content.data.cast::<T::Inner>().as_ref() }
-                    .expect("data should be set"),
-            )
-        })
+        if decoded_content.type_ != T::data_type() {
+            return None;
+        }
+
+        unsafe { decoded_content.data.cast::<T::Inner>().as_ref() }.map(T::raw_ref)
     }
 }

--- a/src/ua/data_types/extension_object.rs
+++ b/src/ua/data_types/extension_object.rs
@@ -1,0 +1,55 @@
+use open62541_sys::UA_ExtensionObjectEncoding;
+
+use crate::{ua, DataType};
+
+crate::data_type!(ExtensionObject);
+
+impl ExtensionObject {
+    /// Gets encoded byte string content.
+    pub fn encoded_content_bytestring(&self) -> Option<(&ua::NodeId, &ua::ByteString)> {
+        match self.0.encoding {
+            UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_ENCODED_BYTESTRING => {}
+            _ => return None,
+        }
+
+        let encoded_content = unsafe { self.0.content.encoded.as_ref() };
+
+        Some((
+            ua::NodeId::raw_ref(&encoded_content.typeId),
+            ua::ByteString::raw_ref(&encoded_content.body),
+        ))
+    }
+
+    /// Gets encoded XML content.
+    pub fn encoded_content_xml(&self) -> Option<(&ua::NodeId, &ua::String)> {
+        match self.0.encoding {
+            UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_ENCODED_XML => {}
+            _ => return None,
+        }
+
+        let encoded_content = unsafe { self.0.content.encoded.as_ref() };
+
+        Some((
+            ua::NodeId::raw_ref(&encoded_content.typeId),
+            ua::String::raw_ref(&encoded_content.body),
+        ))
+    }
+
+    /// Gets decoded content.
+    pub fn decoded_content<T: DataType>(&self) -> Option<&T> {
+        match self.0.encoding {
+            UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_DECODED
+            | UA_ExtensionObjectEncoding::UA_EXTENSIONOBJECT_DECODED_NODELETE => {}
+            _ => return None,
+        }
+
+        let decoded_content = unsafe { self.0.content.decoded.as_ref() };
+
+        (decoded_content.type_ == T::data_type()).then(|| {
+            T::raw_ref(
+                unsafe { decoded_content.data.cast::<T::Inner>().as_ref() }
+                    .expect("data should be set"),
+            )
+        })
+    }
+}

--- a/src/ua/data_types/qualified_name.rs
+++ b/src/ua/data_types/qualified_name.rs
@@ -5,14 +5,25 @@ use crate::{ua, DataType as _};
 crate::data_type!(QualifiedName);
 
 impl QualifiedName {
+    /// Gets namespace index.
     #[must_use]
     pub const fn namespace_index(&self) -> u16 {
         self.0.namespaceIndex
     }
 
+    /// Gets name.
     #[must_use]
     pub fn name(&self) -> &ua::String {
         ua::String::raw_ref(&self.0.name)
+    }
+
+    /// Gets name in namespace 0.
+    ///
+    /// Namespace 0 is always the UA namespace `http://opcfoundation.org/UA/` itself and is used for
+    /// fixed definitions as laid out in the OPC UA specification.
+    #[must_use]
+    pub fn as_ns0(&self) -> Option<&ua::String> {
+        (self.namespace_index() == 0).then(|| self.name())
     }
 }
 

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -81,6 +81,7 @@ impl Variant {
             Double,   // Data type ns=0;i=11
             String,   // Data type ns=0;i=12
             DateTime, // Data type ns=0;i=13
+            Argument, // Data type ns=0;i=296
         );
 
         ua::VariantValue::Scalar(ua::ScalarValue::Unknown)

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -1,7 +1,8 @@
 use std::ffi::c_void;
 
 use open62541_sys::{
-    UA_Variant_hasScalarType, UA_Variant_isEmpty, UA_Variant_isScalar, UA_Variant_setScalarCopy,
+    UA_Variant_hasArrayType, UA_Variant_hasScalarType, UA_Variant_isEmpty, UA_Variant_isScalar,
+    UA_Variant_setScalarCopy,
 };
 
 use crate::{data_type::DataType, ua};
@@ -45,6 +46,14 @@ impl Variant {
             return None;
         }
         unsafe { self.0.data.cast::<T::Inner>().as_ref() }.map(|value| T::clone_raw(value))
+    }
+
+    #[must_use]
+    pub fn to_array<T: DataType>(&self) -> Option<ua::Array<T>> {
+        if !unsafe { UA_Variant_hasArrayType(self.as_ptr(), T::data_type()) } {
+            return None;
+        }
+        ua::Array::from_raw_parts(self.0.data.cast::<T::Inner>(), self.0.arrayLength)
     }
 
     #[must_use]

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -68,20 +68,26 @@ impl Variant {
         }
 
         check!(
-            Boolean,  // Data type ns=0;i=1
-            SByte,    // Data type ns=0;i=2
-            Byte,     // Data type ns=0;i=3
-            Int16,    // Data type ns=0;i=4
-            UInt16,   // Data type ns=0;i=5
-            Int32,    // Data type ns=0;i=6
-            UInt32,   // Data type ns=0;i=7
-            Int64,    // Data type ns=0;i=8
-            UInt64,   // Data type ns=0;i=9
-            Float,    // Data type ns=0;i=10
-            Double,   // Data type ns=0;i=11
-            String,   // Data type ns=0;i=12
-            DateTime, // Data type ns=0;i=13
-            Argument, // Data type ns=0;i=296
+            Boolean,        // Data type ns=0;i=1
+            SByte,          // Data type ns=0;i=2
+            Byte,           // Data type ns=0;i=3
+            Int16,          // Data type ns=0;i=4
+            UInt16,         // Data type ns=0;i=5
+            Int32,          // Data type ns=0;i=6
+            UInt32,         // Data type ns=0;i=7
+            Int64,          // Data type ns=0;i=8
+            UInt64,         // Data type ns=0;i=9
+            Float,          // Data type ns=0;i=10
+            Double,         // Data type ns=0;i=11
+            String,         // Data type ns=0;i=12
+            DateTime,       // Data type ns=0;i=13
+            ByteString,     // Data type ns=0;i=15
+            NodeId,         // Data type ns=0;i=17
+            ExpandedNodeId, // Data type ns=0;i=18
+            StatusCode,     // Data type ns=0;i=19
+            QualifiedName,  // Data type ns=0;i=20
+            LocalizedText,  // Data type ns=0;i=21
+            Argument,       // Data type ns=0;i=296
         );
 
         ua::VariantValue::Scalar(ua::ScalarValue::Unknown)
@@ -101,7 +107,7 @@ impl serde::Serialize for Variant {
         S: serde::Serializer,
     {
         macro_rules! serialize {
-            ($self:ident, $serializer:ident, [$( $( #[cfg($cfg: meta)] )? $name:ident ),* $(,)?]) => {
+            ($self:ident, $serializer:ident, [$( $( #[cfg($cfg: meta)] )? $name:ident ),* $(,)?] $(,)?) => {
                 $(
                     $( #[cfg($cfg)] )?
                     if let Some(value) = self.as_scalar::<crate::ua::$name>() {
@@ -129,8 +135,19 @@ impl serde::Serialize for Variant {
                 String,  // Data type ns=0;i=12
                 #[cfg(feature = "time")]
                 DateTime, // Data type ns=0;i=13
-            ]
+                ByteString, // Data type ns=0;i=15
+                NodeId,  // Data type ns=0;i=17
+            ],
         );
+
+        // The following types are deliberately missing from the list abvove because we don't have a
+        // good serialization for them:
+        //
+        // - ExpandedNodeId, // Data type ns=0;i=18
+        // - StatusCode,     // Data type ns=0;i=19
+        // - QualifiedName,  // Data type ns=0;i=20
+        // - LocalizedText,  // Data type ns=0;i=21
+        // - Argument,       // Data type ns=0;i=296
 
         Err(serde::ser::Error::custom("non-primitive value in Variant"))
     }

--- a/src/ua/values.rs
+++ b/src/ua/values.rs
@@ -27,6 +27,7 @@ pub enum ScalarValue {
     Double(ua::Double),     // Data type ns=0;i=11
     String(ua::String),     // Data type ns=0;i=12
     DateTime(ua::DateTime), // Data type ns=0;i=13
+    Argument(ua::Argument), // Data type ns=0;i=296
 }
 
 /// Value that may be invalid or empty.

--- a/src/ua/values.rs
+++ b/src/ua/values.rs
@@ -14,20 +14,26 @@ pub enum VariantValue {
 #[derive(Debug, Clone)]
 pub enum ScalarValue {
     Unknown,
-    Boolean(ua::Boolean),   // Data type ns=0;i=1
-    SByte(ua::SByte),       // Data type ns=0;i=2
-    Byte(ua::Byte),         // Data type ns=0;i=3
-    Int16(ua::Int16),       // Data type ns=0;i=4
-    UInt16(ua::UInt16),     // Data type ns=0;i=5
-    Int32(ua::Int32),       // Data type ns=0;i=6
-    UInt32(ua::UInt32),     // Data type ns=0;i=7
-    Int64(ua::Int64),       // Data type ns=0;i=8
-    UInt64(ua::UInt64),     // Data type ns=0;i=9
-    Float(ua::Float),       // Data type ns=0;i=10
-    Double(ua::Double),     // Data type ns=0;i=11
-    String(ua::String),     // Data type ns=0;i=12
-    DateTime(ua::DateTime), // Data type ns=0;i=13
-    Argument(ua::Argument), // Data type ns=0;i=296
+    Boolean(ua::Boolean),               // Data type ns=0;i=1
+    SByte(ua::SByte),                   // Data type ns=0;i=2
+    Byte(ua::Byte),                     // Data type ns=0;i=3
+    Int16(ua::Int16),                   // Data type ns=0;i=4
+    UInt16(ua::UInt16),                 // Data type ns=0;i=5
+    Int32(ua::Int32),                   // Data type ns=0;i=6
+    UInt32(ua::UInt32),                 // Data type ns=0;i=7
+    Int64(ua::Int64),                   // Data type ns=0;i=8
+    UInt64(ua::UInt64),                 // Data type ns=0;i=9
+    Float(ua::Float),                   // Data type ns=0;i=10
+    Double(ua::Double),                 // Data type ns=0;i=11
+    String(ua::String),                 // Data type ns=0;i=12
+    DateTime(ua::DateTime),             // Data type ns=0;i=13
+    ByteString(ua::ByteString),         // Data type ns=0;i=15
+    NodeId(ua::NodeId),                 // Data type ns=0;i=17
+    ExpandedNodeId(ua::ExpandedNodeId), // Data type ns=0;i=18
+    StatusCode(ua::StatusCode),         // Data type ns=0;i=19
+    QualifiedName(ua::QualifiedName),   // Data type ns=0;i=20
+    LocalizedText(ua::LocalizedText),   // Data type ns=0;i=21
+    Argument(ua::Argument),             // Data type ns=0;i=296
 }
 
 /// Value that may be invalid or empty.


### PR DESCRIPTION
## Description

This PR adds the data types `Argument` and `ExtensionObject` and adds missing methods and cleans up existing ones that deal with node IDs.