### PR TITLE
Replace ValueType::Unsupported with UnsupportedValueType

### DIFF
--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use open62541::{ua, AsyncClient, DataType as _, ValueType};
+use open62541::{ua, AsyncClient, DataType as _, UnsupportedValueType, ValueType};
 use open62541_sys::{UA_NS0ID_HASPROPERTY, UA_NS0ID_PROPERTYTYPE};
 
 const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
@@ -77,8 +77,8 @@ async fn call_method(
 
 #[derive(Debug)]
 struct MethodDefinition {
-    input_arguments: Option<Vec<(ua::String, ValueType)>>,
-    output_arguments: Option<Vec<(ua::String, ValueType)>>,
+    input_arguments: Option<Vec<(ua::String, Result<ValueType, UnsupportedValueType>)>>,
+    output_arguments: Option<Vec<(ua::String, Result<ValueType, UnsupportedValueType>)>>,
 }
 
 const INPUT_ARGUMENTS_PROPERTY_NAME: &str = "InputArguments";
@@ -168,7 +168,9 @@ async fn read_sparse_node_values(
 ///
 /// This looks into the value returned from reading `InputArguments` and `OutputArguments` property
 /// and returns the list of argument names and their value types.
-fn get_arguments(value: &ua::DataValue) -> anyhow::Result<Vec<(ua::String, ValueType)>> {
+fn get_arguments(
+    value: &ua::DataValue,
+) -> anyhow::Result<Vec<(ua::String, Result<ValueType, UnsupportedValueType>)>> {
     // `InputArguments` and `OutputArguments` nodes are expected to hold an array of objects of the
     // `Argument` type.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use self::{
     data_type::DataType,
     error::{Error, Result},
     userdata::Userdata,
-    value::{ScalarValue, ValueType, VariantValue},
+    value::{ScalarValue, UnsupportedValueType, ValueType, VariantValue},
 };
 pub(crate) use self::{
     data_type::{data_type, enum_variants},

--- a/src/ua/data_types/argument.rs
+++ b/src/ua/data_types/argument.rs
@@ -1,4 +1,4 @@
-use crate::{ua, DataType, ValueType};
+use crate::{ua, value::UnsupportedValueType, DataType, ValueType};
 
 crate::data_type!(Argument);
 
@@ -29,8 +29,12 @@ impl Argument {
         ua::LocalizedText::raw_ref(&self.0.description)
     }
 
-    #[must_use]
-    pub fn value_type(&self) -> ValueType {
+    /// Gets value type of the argument.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data type is not supported (yet).
+    pub fn value_type(&self) -> Result<ValueType, UnsupportedValueType> {
         ValueType::from_data_type(self.data_type())
     }
 }

--- a/src/ua/data_types/argument.rs
+++ b/src/ua/data_types/argument.rs
@@ -1,4 +1,4 @@
-use crate::{ua, value::UnsupportedValueType, DataType, ValueType};
+use crate::{ua, DataType, UnsupportedValueType, ValueType};
 
 crate::data_type!(Argument);
 

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -6,7 +6,7 @@ use open62541_sys::{
 };
 
 use crate::{
-    ua, value::UnsupportedValueType, DataType, NonScalarValue, ScalarValue, ValueType, VariantValue,
+    ua, DataType, NonScalarValue, ScalarValue, UnsupportedValueType, ValueType, VariantValue,
 };
 
 crate::data_type!(Variant);


### PR DESCRIPTION
Use types to make illegal states unrepresentable.