### PR TITLE
Simplify return type of call_method()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Return `Result` instead of raw `ua::DataValue` from `AsyncClient::read_attributes()`.
 - Breaking: Move `ua::VariantValue` and `ua::ScalarValue` to top-level export outside `ua`
 - Breaking: Remove `ua::ArrayValue` for now (until we have a better interface).
+- Breaking: Return output arguments directly from `AsyncClient::call_method()`, without `Option`.
 
 ### Fixed
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -32,7 +32,6 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     let value: i32 = output_arguments
-        .ok_or(anyhow!("output arguments"))?
         .first()
         .ok_or(anyhow!("output argument"))?
         .to_scalar::<ua::Int32>()
@@ -49,7 +48,7 @@ async fn call_method(
     object_node_id: &ua::NodeId,
     method_node_id: &ua::NodeId,
     input_arguments: &[ua::Variant],
-) -> anyhow::Result<Option<Vec<ua::Variant>>> {
+) -> anyhow::Result<Vec<ua::Variant>> {
     println!("Getting method definition of node {method_node_id}");
 
     let definition = get_definition(client, method_node_id).await?;

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -236,7 +236,7 @@ impl AsyncClient {
         object_id: &ua::NodeId,
         method_id: &ua::NodeId,
         input_arguments: &[ua::Variant],
-    ) -> Result<Option<Vec<ua::Variant>>> {
+    ) -> Result<Vec<ua::Variant>> {
         let request =
             ua::CallRequest::init().with_methods_to_call(&[ua::CallMethodRequest::init()
                 .with_object_id(object_id)
@@ -255,11 +255,14 @@ impl AsyncClient {
 
         Error::verify_good(&result.status_code())?;
 
-        let Some(output_arguments) = result.output_arguments() else {
-            return Ok(None);
+        let output_arguments = if let Some(output_arguments) = result.output_arguments() {
+            output_arguments.into_vec()
+        } else {
+            log::debug!("Calling {method_id} returned unset output arguments, assuming none exist");
+            Vec::new()
         };
 
-        Ok(Some(output_arguments.into_vec()))
+        Ok(output_arguments)
     }
 
     /// Browses specific node.


### PR DESCRIPTION
## Description

This removes the unnecessary `Option` from the return type of `AsyncClient::call_method()`. It was used to indicate that the method returned an unset (invalid) array of output arguments but that should not happen within the specification.[^1]

[^1]: In any case, it would be unclear what the meaning behind this was when the call itself was successful.

We treat this as an empty list of output arguments, similar to what we did for `AsyncClient::browse()` in #77.