### PR TITLE
Add options to ClientBuilder, clean up disconnect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `Debug` implementation for `ua::Array<T>` data types.
 - Add `ValueType` enum to check `ua::Variant` without unwrapping (also `ua::Argument`).
 - Add tracing log messages when processing service requests and responses.
+- Add methods to `ClientBuilder` to set response timeout and client description.
 
 ### Changed
 
@@ -33,6 +34,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to `ua::StatusCode::GOOD`.
 - No longer panic when unwrapping `ua::Variant` with array value.
 - Allow invalid references array in `ua::BrowseResult` when request was otherwise successful.
+- Handle graceful disconnection when dropping synchronous `Client`.
 
 ## [0.5.0] - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `Debug` implementation for `ua::Array<T>` data types.
 - Add `ValueType` enum to check `ua::Variant` without unwrapping (also `ua::Argument`).
 - Add tracing log messages when processing service requests and responses.
-- Add methods to `ClientBuilder` to set response timeout and client description.
+- Add methods to `ClientBuilder` to set response timeout, client description, and connectivity check
+  interval.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Move `ua::VariantValue` and `ua::ScalarValue` to top-level export outside `ua`
 - Breaking: Remove `ua::ArrayValue` for now (until we have a better interface).
 - Breaking: Return output arguments directly from `AsyncClient::call_method()`, without `Option`.
+- Breaking: Remove misleading `FromStr` trait implementation and offer `ua::String::new()` instead.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,7 @@ required-features = ["tokio"]
 name = "async_send_sync"
 path = "examples/async_send_sync.rs"
 required-features = ["time", "tokio"]
+
+[[example]]
+name = "client_builder"
+path = "examples/client_builder.rs"

--- a/examples/client_builder.rs
+++ b/examples/client_builder.rs
@@ -19,9 +19,9 @@ fn main() -> anyhow::Result<()> {
 
     println!("Connected successfully");
 
-    println!("Disconnecting client");
+    println!("Dropping client");
 
-    client.disconnect().context("disconnect")?;
+    drop(client);
 
     Ok(())
 }

--- a/examples/client_builder.rs
+++ b/examples/client_builder.rs
@@ -1,0 +1,27 @@
+use anyhow::Context as _;
+use open62541::{ua, ClientBuilder, DataType as _};
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let client_description = ua::ApplicationDescription::init()
+        .with_application_uri("https://crates.io/crates/open62541")
+        .with_product_uri("https://crates.io/crates/open62541")
+        .with_application_name("en-US", "open62541")
+        .with_application_type(ua::ApplicationType::CLIENT);
+
+    println!("Client description: {client_description:?}");
+
+    let client = ClientBuilder::default()
+        .client_description(client_description)
+        .connect("opc.tcp://opcuademo.sterfive.com:26543")
+        .context("connect")?;
+
+    println!("Connected successfully");
+
+    println!("Disconnecting client");
+
+    client.disconnect().context("disconnect")?;
+
+    Ok(())
+}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use open62541_sys::{
-    UA_Client, UA_Client_disconnect, UA_Client_run_iterate, UA_Client_sendAsyncRequest, UA_UInt32,
+    UA_Client, UA_Client_run_iterate, UA_Client_sendAsyncRequest, UA_UInt32,
     UA_STATUSCODE_BADDISCONNECT,
 };
 use tokio::{
@@ -21,6 +21,8 @@ use crate::{
 };
 
 /// Connected OPC UA client (with asynchronous API).
+///
+/// See [Client](crate::Client) for more details.
 pub struct AsyncClient {
     client: Arc<Mutex<ua::Client>>,
     background_handle: JoinHandle<()>,
@@ -378,11 +380,8 @@ impl AsyncClient {
 
 impl Drop for AsyncClient {
     fn drop(&mut self) {
+        // Abort background task (at the interval await point).
         self.background_handle.abort();
-
-        if let Ok(mut client) = self.client.lock() {
-            let _unused = unsafe { UA_Client_disconnect(client.as_mut_ptr()) };
-        }
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,7 @@ use crate::{ua, DataType as _, Error, Result};
 /// # async fn main() -> anyhow::Result<()> {
 /// #
 /// let client = ClientBuilder::default()
-///     .secure_channel_lifetime(Duration::from_secs(60))
+///     .secure_channel_life_time(Duration::from_secs(60))
 ///     .connect("opc.tcp://opcuademo.sterfive.com:26543")?;
 /// #
 /// # Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -172,7 +172,8 @@ impl Default for ClientBuilder {
 /// If the connection fails unrecoverably, the client is no longer usable. In this case create a new
 /// client if required.
 ///
-/// To disconnect, drop the client. Disconnection is always performed async (without blocking).
+/// To disconnect, drop the client. Disconnection is always performed synchronously (with blocking),
+/// for the server to handle the CloseSession request.
 pub struct Client(ua::Client);
 
 impl Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,8 @@ use std::{
 
 use open62541_sys::{
     vsnprintf_va_copy, vsnprintf_va_end, UA_ClientConfig, UA_ClientConfig_setDefault,
-    UA_Client_connect, UA_Client_getConfig, UA_LogCategory, UA_LogLevel, UA_STATUSCODE_GOOD,
+    UA_Client_connect, UA_Client_disconnect, UA_Client_getConfig, UA_LogCategory, UA_LogLevel,
+    UA_STATUSCODE_GOOD,
 };
 
 use crate::{ua, DataType as _, Error, Result};
@@ -188,6 +189,18 @@ impl Client {
     /// See [`ClientBuilder::connect()`].
     pub fn new(endpoint_url: &str) -> Result<Self> {
         ClientBuilder::default().connect(endpoint_url)
+    }
+
+    /// Disconnects client.
+    ///
+    /// This gracefully disconnects the client and should be preferred over simply dropping it.
+    pub fn disconnect(mut self) -> Result<()> {
+        log::info!("Disconnecting from endpoint");
+
+        let status_code = ua::StatusCode::new(unsafe { UA_Client_disconnect(self.0.as_mut_ptr()) });
+        Error::verify_good(&status_code)?;
+
+        Ok(())
     }
 
     /// Turns client into [`AsyncClient`].

--- a/src/client.rs
+++ b/src/client.rs
@@ -67,9 +67,9 @@ impl ClientBuilder {
     /// The given duration must be non-negative and less than 4,294,967,295 milliseconds (less than
     /// 49.7 days).
     #[must_use]
-    pub fn secure_channel_lifetime(mut self, secure_channel_lifetime: Duration) -> Self {
+    pub fn secure_channel_life_time(mut self, secure_channel_life_time: Duration) -> Self {
         self.config_mut().secureChannelLifeTime =
-            u32::try_from(secure_channel_lifetime.as_millis())
+            u32::try_from(secure_channel_life_time.as_millis())
                 .expect("secure channel life time (in milliseconds) should be in range of u32");
         self
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -174,7 +174,10 @@ impl Default for ClientBuilder {
 ///
 /// To disconnect, drop the client. Disconnection is always performed synchronously (with blocking),
 /// for the server to handle the underlying `CloseSession` request.
-pub struct Client(ua::Client);
+pub struct Client(
+    #[allow(dead_code)] // --no-default-features
+    ua::Client,
+);
 
 impl Client {
     /// Creates client connected to endpoint.

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,11 +43,9 @@ impl ClientBuilder {
     /// 49.7 days).
     #[must_use]
     pub fn secure_channel_lifetime(mut self, secure_channel_lifetime: Duration) -> Self {
-        let config = unsafe { UA_Client_getConfig(self.0.as_mut_ptr()).as_mut() };
-
-        config.unwrap().secureChannelLifeTime = u32::try_from(secure_channel_lifetime.as_millis())
-            .expect("secure channel life time should be in range of u32");
-
+        self.config_mut().secureChannelLifeTime =
+            u32::try_from(secure_channel_lifetime.as_millis())
+                .expect("secure channel life time (in milliseconds) should be in range of u32");
         self
     }
 
@@ -59,12 +57,9 @@ impl ClientBuilder {
     /// 49.7 days).
     #[must_use]
     pub fn requested_session_timeout(mut self, requested_session_timeout: Duration) -> Self {
-        let config = unsafe { UA_Client_getConfig(self.0.as_mut_ptr()).as_mut() };
-
-        config.unwrap().requestedSessionTimeout =
+        self.config_mut().requestedSessionTimeout =
             u32::try_from(requested_session_timeout.as_millis())
-                .expect("secure channel life time should be in range of u32");
-
+                .expect("secure channel life time (in milliseconds) should be in range of u32");
         self
     }
 
@@ -89,6 +84,13 @@ impl ClientBuilder {
         Error::verify_good(&status_code)?;
 
         Ok(Client(self.0))
+    }
+
+    /// Access client configuration.
+    fn config_mut(&mut self) -> &mut UA_ClientConfig {
+        // PANIC: `UA_Client_getConfig()` returns non-null pointer for non-null client argument.
+        unsafe { UA_Client_getConfig(self.0.as_mut_ptr()).as_mut() }
+            .expect("client config should be set")
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -173,7 +173,7 @@ impl Default for ClientBuilder {
 /// client if required.
 ///
 /// To disconnect, drop the client. Disconnection is always performed synchronously (with blocking),
-/// for the server to handle the CloseSession request.
+/// for the server to handle the underlying `CloseSession` request.
 pub struct Client(ua::Client);
 
 impl Client {

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -160,10 +160,12 @@ pub unsafe trait DataType: Debug + Clone {
         assert_eq!(result, UA_STATUSCODE_GOOD, "should have copied value");
     }
 
-    /// Moves value into `dst`.
+    /// Moves value into `dst`, giving up ownership.
     ///
     /// Existing data in `dst` is cleared with [`UA_clear()`] before moving the value; it is safe
     /// to use this operation on already initialized target values.
+    ///
+    /// After this, it is the responsibility of `dst` to eventually clean up the data.
     fn move_into_raw(self, dst: &mut Self::Inner) {
         let dst: *mut Self::Inner = dst;
         // Use `UA_clear()` first to free dynamically allocated memory held by the current value.

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ impl Error {
         }
     }
 
-    #[allow(dead_code)] // Temporarily lift linter warning for `--no-default-features`.
+    #[allow(dead_code)] // --no-default-features
     #[must_use]
     pub(crate) const fn internal(message: &'static str) -> Self {
         Self::Internal(message)

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -237,10 +237,10 @@ impl<T: DataType> Array<T> {
 
     /// Consumes the array elements as an iterator.
     ///
-    /// Replaces the elements of the array by zero-initialized memory. Ownership of the original
-    /// elements is transferred to the resulting iterator items.
+    /// Replaces the elements of the array by default-initialized instances ([`DataType::init()`]).
+    /// Ownership of the original elements is transferred to the resulting iterator items.
     ///
-    /// Other than [`Vec::drain()`], this method does not shrink the array.
+    /// Note: Other than [`Vec::drain()`], this method does _not_ shrink the array.
     // TODO: How to implement `IntoIterator` on `self` instead of `&mut self`?
     #[must_use]
     pub(crate) fn drain_all(&mut self) -> impl ExactSizeIterator<Item = T> + '_ {
@@ -288,10 +288,12 @@ impl<T: DataType> Array<T> {
         (size, ptr)
     }
 
-    /// Moves array into `dst`.
+    /// Moves array into `dst`, giving up ownership.
     ///
     /// Existing data in `dst` is cleared with [`UA_Array_delete()`] before moving the value; it is
     /// safe to use this operation on already initialized target values.
+    ///
+    /// After this, it is the responsibility of `dst` to eventually clean up the data.
     pub(crate) fn move_into_raw(self, dst_size: &mut usize, dst: &mut *mut T::Inner) {
         // Make sure to clean up any previous value in target.
         let _unused = Self::from_raw_parts(*dst, *dst_size);

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -237,9 +237,8 @@ impl<T: DataType> Array<T> {
 
     /// Consumes the array elements as an iterator.
     ///
-    /// Replaces the elements of the array by zero-initialized memory.
-    /// Ownership of the original elements is transferred to the resulting
-    /// iterator items.
+    /// Replaces the elements of the array by zero-initialized memory. Ownership of the original
+    /// elements is transferred to the resulting iterator items.
     ///
     /// Other than [`Vec::drain()`], this method does not shrink the array.
     // TODO: How to implement `IntoIterator` on `self` instead of `&mut self`?
@@ -289,6 +288,10 @@ impl<T: DataType> Array<T> {
         (size, ptr)
     }
 
+    /// Moves array into `dst`.
+    ///
+    /// Existing data in `dst` is cleared with [`UA_Array_delete()`] before moving the value; it is
+    /// safe to use this operation on already initialized target values.
     pub(crate) fn move_into_raw(self, dst_size: &mut usize, dst: &mut *mut T::Inner) {
         // Make sure to clean up any previous value in target.
         let _unused = Self::from_raw_parts(*dst, *dst_size);

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -83,6 +83,11 @@ impl Drop for Client {
     fn drop(&mut self) {
         log::info!("Disconnecting from endpoint");
 
+        // Disconnection is always performed synchronously (with blocking), for the server to handle
+        // the CloseSession request. Looking at the implementation of `UA_Client_disconnect()`, this
+        // seems to be done with a timeout of 10 seconds.
+        //
+        // TODO: Refactor this to avoid blocking in `drop()` for a potentially long time.
         let status_code = ua::StatusCode::new(unsafe { UA_Client_disconnect(self.as_mut_ptr()) });
         if let Err(error) = Error::verify_good(&status_code) {
             log::warn!("Error while disconnecting client: {error}");

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -38,7 +38,7 @@ impl Client {
     /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[allow(dead_code)]
     #[must_use]
-    pub(crate) const fn as_ptr(&self) -> *const UA_Client {
+    pub(crate) const unsafe fn as_ptr(&self) -> *const UA_Client {
         self.0.as_ptr()
     }
 
@@ -49,7 +49,7 @@ impl Client {
     /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
     /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[must_use]
-    pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_Client {
+    pub(crate) unsafe fn as_mut_ptr(&mut self) -> *mut UA_Client {
         self.0.as_ptr()
     }
 
@@ -88,7 +88,7 @@ impl Drop for Client {
             log::warn!("Error while disconnecting client: {error}");
         }
 
-        log::info!("Deleting client");
+        log::debug!("Deleting client");
 
         // `UA_Client_delete()` matches `UA_Client_new()`.
         unsafe { UA_Client_delete(self.as_mut_ptr()) }

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -28,12 +28,24 @@ pub struct Client(NonNull<UA_Client>);
 unsafe impl Send for Client {}
 
 impl Client {
+    /// Returns const pointer to value.
+    ///
+    /// # Safety
+    ///
+    /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
+    /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[allow(dead_code)]
     #[must_use]
     pub(crate) const fn as_ptr(&self) -> *const UA_Client {
         self.0.as_ptr()
     }
 
+    /// Returns mutable pointer to value.
+    ///
+    /// # Safety
+    ///
+    /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
+    /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[must_use]
     pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_Client {
         self.0.as_ptr()
@@ -67,6 +79,8 @@ impl Client {
 
 impl Drop for Client {
     fn drop(&mut self) {
+        log::info!("Deleting client");
+
         // `UA_Client_delete()` matches `UA_Client_new()`.
         unsafe { UA_Client_delete(self.as_mut_ptr()) }
     }

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -1,5 +1,7 @@
 //! Thin wrappers for OPC UA data types from [`open62541_sys`].
 
+mod application_description;
+mod application_type;
 mod argument;
 mod attribute_id;
 mod browse_description;
@@ -47,6 +49,7 @@ mod write_response;
 mod write_value;
 
 pub use self::{
+    application_description::ApplicationDescription, application_type::ApplicationType,
     argument::Argument, attribute_id::AttributeId, browse_description::BrowseDescription,
     browse_direction::BrowseDirection, browse_next_request::BrowseNextRequest,
     browse_next_response::BrowseNextResponse, browse_request::BrowseRequest,

--- a/src/ua/data_types/application_description.rs
+++ b/src/ua/data_types/application_description.rs
@@ -1,0 +1,66 @@
+use std::str::FromStr;
+
+use crate::{ua, DataType as _};
+
+crate::data_type!(ApplicationDescription);
+
+/// Typically, `ApplicationDescription` is generated from static data. Therefore, the methods below
+/// do not return `Result` but panic instead when the given strings are invalid (when they contain
+/// NUL bytes).
+impl ApplicationDescription {
+    #[must_use]
+    pub fn with_application_uri(mut self, application_uri: &str) -> Self {
+        ua::String::from_str(application_uri)
+            .unwrap()
+            .move_into_raw(&mut self.0.applicationUri);
+        self
+    }
+
+    #[must_use]
+    pub fn with_product_uri(mut self, product_uri: &str) -> Self {
+        ua::String::from_str(product_uri)
+            .unwrap()
+            .move_into_raw(&mut self.0.productUri);
+        self
+    }
+
+    #[must_use]
+    pub fn with_application_name(mut self, locale: &str, application_name: &str) -> Self {
+        ua::LocalizedText::try_from((locale, application_name))
+            .unwrap()
+            .move_into_raw(&mut self.0.applicationName);
+        self
+    }
+
+    #[must_use]
+    pub fn with_application_type(mut self, application_type: ua::ApplicationType) -> Self {
+        application_type.move_into_raw(&mut self.0.applicationType);
+        self
+    }
+
+    #[must_use]
+    pub fn with_gateway_server_uri(mut self, gateway_server_uri: &str) -> Self {
+        ua::String::from_str(gateway_server_uri)
+            .unwrap()
+            .move_into_raw(&mut self.0.gatewayServerUri);
+        self
+    }
+
+    #[must_use]
+    pub fn with_discovery_profile_uri(mut self, discovery_profile_uri: &str) -> Self {
+        ua::String::from_str(discovery_profile_uri)
+            .unwrap()
+            .move_into_raw(&mut self.0.discoveryProfileUri);
+        self
+    }
+
+    #[must_use]
+    pub fn with_discovery_urls(mut self, discovery_urls: &[&str]) -> Self {
+        let discovery_urls = discovery_urls
+            .iter()
+            .map(|discovery_url| ua::String::from_str(discovery_url).unwrap());
+        ua::Array::from_iter(discovery_urls)
+            .move_into_raw(&mut self.0.discoveryUrlsSize, &mut self.0.discoveryUrls);
+        self
+    }
+}

--- a/src/ua/data_types/application_description.rs
+++ b/src/ua/data_types/application_description.rs
@@ -8,6 +8,11 @@ crate::data_type!(ApplicationDescription);
 /// do not return `Result` but panic instead when the given strings are invalid (when they contain
 /// NUL bytes).
 impl ApplicationDescription {
+    /// Sets application URI.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_application_uri(mut self, application_uri: &str) -> Self {
         ua::String::from_str(application_uri)
@@ -16,6 +21,11 @@ impl ApplicationDescription {
         self
     }
 
+    /// Sets product URI.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_product_uri(mut self, product_uri: &str) -> Self {
         ua::String::from_str(product_uri)
@@ -24,6 +34,11 @@ impl ApplicationDescription {
         self
     }
 
+    /// Sets application name (with locale).
+    ///
+    /// # Panics
+    ///
+    /// The strings must not contain any NUL bytes.
     #[must_use]
     pub fn with_application_name(mut self, locale: &str, application_name: &str) -> Self {
         ua::LocalizedText::try_from((locale, application_name))
@@ -32,12 +47,19 @@ impl ApplicationDescription {
         self
     }
 
+    /// Sets application type.
+    ///
     #[must_use]
     pub fn with_application_type(mut self, application_type: ua::ApplicationType) -> Self {
         application_type.move_into_raw(&mut self.0.applicationType);
         self
     }
 
+    /// Sets gateway server URI.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_gateway_server_uri(mut self, gateway_server_uri: &str) -> Self {
         ua::String::from_str(gateway_server_uri)
@@ -46,6 +68,11 @@ impl ApplicationDescription {
         self
     }
 
+    /// Sets discovery profile URI.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_discovery_profile_uri(mut self, discovery_profile_uri: &str) -> Self {
         ua::String::from_str(discovery_profile_uri)
@@ -54,6 +81,11 @@ impl ApplicationDescription {
         self
     }
 
+    /// Sets discovery URLs.
+    ///
+    /// # Panics
+    ///
+    /// The strings must not contain any NUL bytes.
     #[must_use]
     pub fn with_discovery_urls(mut self, discovery_urls: &[&str]) -> Self {
         let discovery_urls = discovery_urls

--- a/src/ua/data_types/application_description.rs
+++ b/src/ua/data_types/application_description.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::{ua, DataType as _};
 
 crate::data_type!(ApplicationDescription);
@@ -15,7 +13,7 @@ impl ApplicationDescription {
     /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_application_uri(mut self, application_uri: &str) -> Self {
-        ua::String::from_str(application_uri)
+        ua::String::new(application_uri)
             .unwrap()
             .move_into_raw(&mut self.0.applicationUri);
         self
@@ -28,7 +26,7 @@ impl ApplicationDescription {
     /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_product_uri(mut self, product_uri: &str) -> Self {
-        ua::String::from_str(product_uri)
+        ua::String::new(product_uri)
             .unwrap()
             .move_into_raw(&mut self.0.productUri);
         self
@@ -41,7 +39,7 @@ impl ApplicationDescription {
     /// The strings must not contain any NUL bytes.
     #[must_use]
     pub fn with_application_name(mut self, locale: &str, application_name: &str) -> Self {
-        ua::LocalizedText::try_from((locale, application_name))
+        ua::LocalizedText::new(locale, application_name)
             .unwrap()
             .move_into_raw(&mut self.0.applicationName);
         self
@@ -62,7 +60,7 @@ impl ApplicationDescription {
     /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_gateway_server_uri(mut self, gateway_server_uri: &str) -> Self {
-        ua::String::from_str(gateway_server_uri)
+        ua::String::new(gateway_server_uri)
             .unwrap()
             .move_into_raw(&mut self.0.gatewayServerUri);
         self
@@ -75,7 +73,7 @@ impl ApplicationDescription {
     /// The string must not contain any NUL bytes.
     #[must_use]
     pub fn with_discovery_profile_uri(mut self, discovery_profile_uri: &str) -> Self {
-        ua::String::from_str(discovery_profile_uri)
+        ua::String::new(discovery_profile_uri)
             .unwrap()
             .move_into_raw(&mut self.0.discoveryProfileUri);
         self
@@ -90,7 +88,7 @@ impl ApplicationDescription {
     pub fn with_discovery_urls(mut self, discovery_urls: &[&str]) -> Self {
         let discovery_urls = discovery_urls
             .iter()
-            .map(|discovery_url| ua::String::from_str(discovery_url).unwrap());
+            .map(|discovery_url| ua::String::new(discovery_url).unwrap());
         ua::Array::from_iter(discovery_urls)
             .move_into_raw(&mut self.0.discoveryUrlsSize, &mut self.0.discoveryUrls);
         self

--- a/src/ua/data_types/application_type.rs
+++ b/src/ua/data_types/application_type.rs
@@ -1,0 +1,7 @@
+crate::data_type!(ApplicationType, UInt32);
+
+crate::enum_variants!(
+    ApplicationType,
+    UA_ApplicationType,
+    [SERVER, CLIENT, CLIENTANDSERVER, DISCOVERYSERVER],
+);

--- a/src/ua/data_types/localized_text.rs
+++ b/src/ua/data_types/localized_text.rs
@@ -5,11 +5,17 @@ use crate::{ua, DataType as _, Error};
 crate::data_type!(LocalizedText);
 
 impl LocalizedText {
+    /// # Errors
+    ///
+    /// The string must not contain any NUL bytes.
     pub fn with_locale(mut self, locale: &str) -> Result<Self, Error> {
         ua::String::from_str(locale)?.move_into_raw(&mut self.0.locale);
         Ok(self)
     }
 
+    /// # Errors
+    ///
+    /// The string must not contain any NUL bytes.
     pub fn with_text(mut self, text: &str) -> Result<Self, Error> {
         ua::String::from_str(text)?.move_into_raw(&mut self.0.text);
         Ok(self)
@@ -30,6 +36,6 @@ impl TryFrom<(&str, &str)> for LocalizedText {
     type Error = Error;
 
     fn try_from((locale, text): (&str, &str)) -> Result<Self, Self::Error> {
-        Ok(Self::init().with_locale(locale)?.with_text(text)?)
+        Self::init().with_locale(locale)?.with_text(text)
     }
 }

--- a/src/ua/data_types/localized_text.rs
+++ b/src/ua/data_types/localized_text.rs
@@ -1,15 +1,22 @@
-use std::str::FromStr;
-
 use crate::{ua, DataType as _, Error};
 
 crate::data_type!(LocalizedText);
 
 impl LocalizedText {
+    /// Creates localized text from locale and text.
+    ///
+    /// # Errors
+    ///
+    /// The strings must not contain any NUL bytes.
+    pub fn new(locale: &str, text: &str) -> Result<Self, Error> {
+        Self::init().with_locale(locale)?.with_text(text)
+    }
+
     /// # Errors
     ///
     /// The string must not contain any NUL bytes.
     pub fn with_locale(mut self, locale: &str) -> Result<Self, Error> {
-        ua::String::from_str(locale)?.move_into_raw(&mut self.0.locale);
+        ua::String::new(locale)?.move_into_raw(&mut self.0.locale);
         Ok(self)
     }
 
@@ -17,7 +24,7 @@ impl LocalizedText {
     ///
     /// The string must not contain any NUL bytes.
     pub fn with_text(mut self, text: &str) -> Result<Self, Error> {
-        ua::String::from_str(text)?.move_into_raw(&mut self.0.text);
+        ua::String::new(text)?.move_into_raw(&mut self.0.text);
         Ok(self)
     }
 
@@ -29,13 +36,5 @@ impl LocalizedText {
     #[must_use]
     pub fn text(&self) -> &ua::String {
         ua::String::raw_ref(&self.0.text)
-    }
-}
-
-impl TryFrom<(&str, &str)> for LocalizedText {
-    type Error = Error;
-
-    fn try_from((locale, text): (&str, &str)) -> Result<Self, Self::Error> {
-        Self::init().with_locale(locale)?.with_text(text)
     }
 }

--- a/src/ua/data_types/localized_text.rs
+++ b/src/ua/data_types/localized_text.rs
@@ -1,8 +1,20 @@
-use crate::{ua, DataType as _};
+use std::str::FromStr;
+
+use crate::{ua, DataType as _, Error};
 
 crate::data_type!(LocalizedText);
 
 impl LocalizedText {
+    pub fn with_locale(mut self, locale: &str) -> Result<Self, Error> {
+        ua::String::from_str(locale)?.move_into_raw(&mut self.0.locale);
+        Ok(self)
+    }
+
+    pub fn with_text(mut self, text: &str) -> Result<Self, Error> {
+        ua::String::from_str(text)?.move_into_raw(&mut self.0.text);
+        Ok(self)
+    }
+
     #[must_use]
     pub fn locale(&self) -> &ua::String {
         ua::String::raw_ref(&self.0.locale)
@@ -11,5 +23,13 @@ impl LocalizedText {
     #[must_use]
     pub fn text(&self) -> &ua::String {
         ua::String::raw_ref(&self.0.text)
+    }
+}
+
+impl TryFrom<(&str, &str)> for LocalizedText {
+    type Error = Error;
+
+    fn try_from((locale, text): (&str, &str)) -> Result<Self, Self::Error> {
+        Ok(Self::init().with_locale(locale)?.with_text(text)?)
     }
 }

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -123,7 +123,7 @@ impl str::FromStr for NodeId {
         let mut node_id = NodeId::init();
 
         let status_code = ua::StatusCode::new({
-            let str: ua::String = s.parse()?;
+            let str = ua::String::new(s)?;
             // SAFETY: `UA_NodeId_parse()` expects the string passed by value but does not take
             // ownership.
             let str = unsafe { ua::String::to_raw_copy(&str) };
@@ -216,7 +216,8 @@ mod tests {
 
     #[test]
     fn string_representation() {
-        // We explicitly derive `FromStr` and `ToString`. This is part of the public interface.
+        // We explicitly derive `FromStr` and `ToString`. This is part of the public interface. This
+        // is the reason why the explicit turbofish syntax is used below.
         //
         let node_id =
             <ua::NodeId as str::FromStr>::from_str("ns=0;i=2258").expect("should be valid node ID");

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -244,8 +244,6 @@ mod tests {
 
     #[cfg(feature = "serde")]
     mod serde {
-        use std::str::FromStr as _;
-
         use crate::{ua, DataType as _};
 
         #[test]
@@ -308,19 +306,19 @@ mod tests {
         #[test]
         fn serialize_string() {
             // Empty string
-            let ua_string = ua::String::from_str("").unwrap();
+            let ua_string = ua::String::new("").unwrap();
             let ua_variant = ua::Variant::init().with_scalar(&ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""""#, json);
 
             // Short string
-            let ua_string = ua::String::from_str("lorem ipsum").unwrap();
+            let ua_string = ua::String::new("lorem ipsum").unwrap();
             let ua_variant = ua::Variant::init().with_scalar(&ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""lorem ipsum""#, json);
 
             // Special characters
-            let ua_string = ua::String::from_str(r#"a'b"c{dẞe"#).unwrap();
+            let ua_string = ua::String::new(r#"a'b"c{dẞe"#).unwrap();
             let ua_variant = ua::Variant::init().with_scalar(&ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""a'b\"c{dẞe""#, json);


### PR DESCRIPTION
## Description

This adds more options to `ClientBuilder` to set the response timeout and client description.

It also cleans up handling of disconnect when dropping a synchronous `Client` instance (previously, only `AsyncClient` would disconnect gracefully when dropped).