### PR TITLE
Fix memory corruption during logger setup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,13 @@
-use std::{ffi::CString, time::Duration};
+use std::{
+    ffi::{c_char, c_void, CStr, CString},
+    ptr,
+    time::Duration,
+};
 
-use open62541_sys::{UA_ClientConfig, UA_Client_connect};
+use open62541_sys::{
+    vsnprintf_va_copy, vsnprintf_va_end, UA_ClientConfig, UA_Client_connect, UA_LogCategory,
+    UA_LogLevel, UA_Logger,
+};
 
 use crate::{ua, DataType as _, Error, Result};
 
@@ -193,4 +200,147 @@ impl Client {
     pub fn disconnect(self) {
         self.0.disconnect()
     }
+}
+
+/// Creates logger that forwards to the `log` crate.
+///
+/// We can use this to prevent `open62541` from installing its own default logger (which outputs any
+/// logs to stdout/stderr directly).
+///
+/// Note that this leaks memory unless the returned pointer is assigned to `UA_ClientConfig` (and/or
+/// `UA_Client` in turn), eventually calling `UA_Logger::clear()` with this `UA_Logger` instance.
+pub(crate) fn client_logger() -> *mut UA_Logger {
+    unsafe extern "C" fn log_c(
+        _log_context: *mut c_void,
+        level: UA_LogLevel,
+        _category: UA_LogCategory,
+        msg: *const c_char,
+        args: open62541_sys::va_list_,
+    ) {
+        let Some(msg) = format_message(msg, args) else {
+            log::error!("Unknown log message");
+            return;
+        };
+
+        let msg = CStr::from_bytes_with_nul(&msg)
+            .expect("string length should match")
+            .to_string_lossy();
+
+        if level == UA_LogLevel::UA_LOGLEVEL_FATAL {
+            // Without fatal level in `log`, fall back to error.
+            log::error!("{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_ERROR {
+            log::error!("{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_WARNING {
+            log::warn!("{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_INFO {
+            log::info!("{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_DEBUG {
+            log::debug!("{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_TRACE {
+            log::trace!("{msg}");
+        } else {
+            // Handle unexpected level by escalating to error.
+            log::error!("{msg}");
+        }
+    }
+
+    unsafe extern "C" fn clear_c(logger: *mut UA_Logger) {
+        log::debug!("Clearing `log` logger");
+
+        // This consumes the `UA_Logger` structure itself, invalidating the pointer `config.logging`
+        // and thereby releasing all allocated resources.
+        //
+        // This is in line with the contract that `config.logging` may not be used anymore after its
+        // `clear()` method has been called.
+        let logger = unsafe { Box::from_raw(logger) };
+
+        // Run some sanity checks. We should only ever be called on our own data structure.
+        debug_assert!(logger.log == Some(log_c));
+        debug_assert!(logger.clear == Some(clear_c));
+
+        // As long as we do not carry data, there is nothing to clean up here.
+        debug_assert!(logger.context.is_null());
+
+        // Dropping the boxed logger cleans up allocated memory.
+        drop(logger);
+    }
+
+    log::debug!("Creating `log` logger");
+
+    // Create logger configuration. We leak the memory which is cleaned up eventually when `clear()`
+    // is called (which is `clear_c()` above).
+    Box::leak(Box::new(UA_Logger {
+        log: Some(log_c),
+        context: ptr::null_mut(),
+        clear: Some(clear_c),
+    }))
+}
+
+/// Initial buffer size when formatting messages.
+const FORMAT_MESSAGE_DEFAULT_BUFFER_LEN: usize = 128;
+
+/// Maximum buffer size when formatting messages.
+const FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN: usize = 65536;
+
+/// Formats message with `vprintf` library calls.
+///
+/// This returns the formatted message with a trailing NUL byte, or `None` when formatting fails. A
+/// long message may be truncated (see [`FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN`] for details); its last
+/// characters will be replaced with `...` to indicate this.
+fn format_message(msg: *const c_char, args: open62541_sys::va_list_) -> Option<Vec<u8>> {
+    // Delegate string formatting to `vsnprintf()`, the length-checked string buffer variant of the
+    // variadic `vprintf` family.
+    //
+    // We use the custom `vsnprintf_va_copy()` provided by `open62541_sys`. This copies the va args
+    // and requires an explicit call to `vsnprintf_va_end()` afterwards.
+
+    // Allocate default buffer first. Only when the message doesn't fit, we need to allocate larger
+    // buffer below.
+    let mut msg_buffer: Vec<u8> = vec![0; FORMAT_MESSAGE_DEFAULT_BUFFER_LEN];
+    loop {
+        let result = unsafe {
+            vsnprintf_va_copy(
+                msg_buffer.as_mut_ptr().cast::<c_char>(),
+                msg_buffer.len(),
+                msg,
+                args,
+            )
+        };
+        let Ok(msg_len) = usize::try_from(result) else {
+            // Negative result is an error in the format string. Nothing we can do.
+            debug_assert!(result < 0);
+            // Free the `va_list` argument that is no consumed by `vsnprintf()`!
+            unsafe { vsnprintf_va_end(args) }
+            return None;
+        };
+        let buffer_len = msg_len + 1;
+        if buffer_len > msg_buffer.len() {
+            // Last byte must always be the NUL terminator, even if the message
+            // doesn't fit into the buffer.
+            debug_assert_eq!(msg_buffer.last(), Some(&0));
+            if msg_buffer.len() < FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN {
+                // Allocate larger buffer and try again.
+                msg_buffer.resize(FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN, 0);
+                continue;
+            }
+            // Message is too large to format. Truncate the message by ending it with `...`.
+            for char in msg_buffer.iter_mut().rev().skip(1).take(3) {
+                *char = b'.';
+            }
+        } else {
+            // Message fits into the buffer. Make sure that `from_bytes_with_nul()`
+            // sees the expected single NUL terminator in the final position.
+            msg_buffer.truncate(buffer_len);
+        }
+        break;
+    }
+
+    // Free the `va_list` argument that is not consumed by `vsnprintf()`!
+    unsafe { vsnprintf_va_end(args) }
+
+    // Last byte must always be the NUL terminator.
+    debug_assert_eq!(msg_buffer.last(), Some(&0));
+
+    Some(msg_buffer)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,6 @@
-use std::{
-    ffi::{c_char, c_void, CStr, CString},
-    ptr,
-    time::Duration,
-};
+use std::{ffi::CString, time::Duration};
 
-use open62541_sys::{
-    vsnprintf_va_copy, vsnprintf_va_end, UA_ClientConfig, UA_ClientConfig_setDefault,
-    UA_Client_connect, UA_Client_getConfig, UA_LogCategory, UA_LogLevel, UA_Logger,
-    UA_STATUSCODE_GOOD,
-};
+use open62541_sys::{UA_ClientConfig, UA_Client_connect};
 
 use crate::{ua, DataType as _, Error, Result};
 
@@ -32,8 +24,9 @@ use crate::{ua, DataType as _, Error, Result};
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Default)]
 #[allow(clippy::module_name_repetitions)]
-pub struct ClientBuilder(ua::Client);
+pub struct ClientBuilder(ua::ClientConfig);
 
 impl ClientBuilder {
     /// Sets (response) timeout.
@@ -117,48 +110,26 @@ impl ClientBuilder {
     /// # Panics
     ///
     /// The endpoint URL must not contain any NUL bytes.
-    pub fn connect(mut self, endpoint_url: &str) -> Result<Client> {
+    pub fn connect(self, endpoint_url: &str) -> Result<Client> {
         log::info!("Connecting to endpoint {endpoint_url}");
 
         let endpoint_url =
             CString::new(endpoint_url).expect("endpoint URL does not contain NUL bytes");
 
+        let mut client = ua::Client::new_with_config(self.0);
+
         let status_code = ua::StatusCode::new(unsafe {
-            UA_Client_connect(self.0.as_mut_ptr(), endpoint_url.as_ptr())
+            UA_Client_connect(client.as_mut_ptr(), endpoint_url.as_ptr())
         });
         Error::verify_good(&status_code)?;
 
-        Ok(Client(self.0))
+        Ok(Client(client))
     }
 
     /// Access client configuration.
     fn config_mut(&mut self) -> &mut UA_ClientConfig {
-        // PANIC: `UA_Client_getConfig()` returns non-null pointer for non-null client argument.
-        unsafe { UA_Client_getConfig(self.0.as_mut_ptr()).as_mut() }
-            .expect("client config should be set")
-    }
-}
-
-impl Default for ClientBuilder {
-    fn default() -> Self {
-        let mut inner = ua::Client::default();
-
-        // We require some initial configuration for `UA_Client_connect()` to work.
-        //
-        let result = unsafe {
-            let config = UA_Client_getConfig(inner.as_mut_ptr());
-
-            // Install custom logger that uses the `log` crate.
-            set_default_logger(config.as_mut().expect("client config should be set"));
-
-            // Initialize remainder of configuration with defaults. This keeps our custom logger. We
-            // do this after `set_default_logger()`: `UA_ClientConfig_setDefault()` would needlessly
-            // install a default logger that we would throw away in `set_default_logger()` anyway.
-            UA_ClientConfig_setDefault(config)
-        };
-        assert!(result == UA_STATUSCODE_GOOD);
-
-        Self(inner)
+        // SAFETY: Ownership is not given away.
+        unsafe { self.0.as_mut() }
     }
 }
 
@@ -222,143 +193,4 @@ impl Client {
     pub fn disconnect(self) {
         self.0.disconnect()
     }
-}
-
-/// Installs logger that forwards to the `log` crate.
-///
-/// This remove an existing logger from the given configuration (by calling its `clear()` callback),
-/// then installs a custom logger that forwards all messages to the corresponding calls in the `log`
-/// crate.
-///
-/// We can use this to prevent `open62541` from installing its own default logger (which outputs any
-/// logs to stdout/stderr directly).
-fn set_default_logger(config: &mut UA_ClientConfig) {
-    unsafe extern "C" fn log_c(
-        _log_context: *mut c_void,
-        level: UA_LogLevel,
-        _category: UA_LogCategory,
-        msg: *const c_char,
-        args: open62541_sys::va_list_,
-    ) {
-        let Some(msg) = format_message(msg, args) else {
-            log::error!("Unknown log message");
-            return;
-        };
-
-        let msg = CStr::from_bytes_with_nul(&msg)
-            .expect("string length should match")
-            .to_string_lossy();
-
-        if level == UA_LogLevel::UA_LOGLEVEL_FATAL {
-            // Without fatal level in `log`, fall back to error.
-            log::error!("{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_ERROR {
-            log::error!("{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_WARNING {
-            log::warn!("{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_INFO {
-            log::info!("{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_DEBUG {
-            log::debug!("{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_TRACE {
-            log::trace!("{msg}");
-        } else {
-            // Handle unexpected level by escalating to error.
-            log::error!("{msg}");
-        }
-    }
-
-    unsafe extern "C" fn clear_c(logger: *mut UA_Logger) {
-        // This consumes the `UA_Logger` structure itself, invalidating the pointer `config.logging`
-        // and thereby releasing all allocated resources.
-        //
-        // This is in line with the contract that `config.logging` may not be used anymore after its
-        // `clear()` method has been called.
-        let _unused = unsafe { Box::from_raw(logger) };
-    }
-
-    // Reset existing logger configuration.
-    if let Some(logger) = unsafe { config.logging.as_ref() } {
-        if let Some(clear) = logger.clear {
-            unsafe { clear(config.logging) };
-        }
-        // Mark logger as removed: the data structure has been deallocated by the call to `clear()`.
-        config.logging = ptr::null_mut();
-    }
-
-    // Create logger configuration. We leak the memory which is cleaned up eventually when `clear()`
-    // is called (which is `clear_c()` above).
-    config.logging = Box::leak(Box::new(UA_Logger {
-        log: Some(log_c),
-        context: ptr::null_mut(),
-        clear: Some(clear_c),
-    }));
-}
-
-/// Initial buffer size when formatting messages.
-const FORMAT_MESSAGE_DEFAULT_BUFFER_LEN: usize = 128;
-
-/// Maximum buffer size when formatting messages.
-const FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN: usize = 65536;
-
-/// Formats message with `vprintf` library calls.
-///
-/// This returns the formatted message with a trailing NUL byte, or `None` when formatting fails. A
-/// long message may be truncated (see [`FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN`] for details); its last
-/// characters will be replaced with `...` to indicate this.
-fn format_message(msg: *const c_char, args: open62541_sys::va_list_) -> Option<Vec<u8>> {
-    // Delegate string formatting to `vsnprintf()`, the length-checked string buffer variant of the
-    // variadic `vprintf` family.
-    //
-    // We use the custom `vsnprintf_va_copy()` provided by `open62541_sys`. This copies the va args
-    // and requires an explicit call to `vsnprintf_va_end()` afterwards.
-
-    // Allocate default buffer first. Only when the message doesn't fit, we need to allocate larger
-    // buffer below.
-    let mut msg_buffer: Vec<u8> = vec![0; FORMAT_MESSAGE_DEFAULT_BUFFER_LEN];
-    loop {
-        let result = unsafe {
-            vsnprintf_va_copy(
-                msg_buffer.as_mut_ptr().cast::<c_char>(),
-                msg_buffer.len(),
-                msg,
-                args,
-            )
-        };
-        let Ok(msg_len) = usize::try_from(result) else {
-            // Negative result is an error in the format string. Nothing we can do.
-            debug_assert!(result < 0);
-            // Free the `va_list` argument that is no consumed by `vsnprintf()`!
-            unsafe { vsnprintf_va_end(args) }
-            return None;
-        };
-        let buffer_len = msg_len + 1;
-        if buffer_len > msg_buffer.len() {
-            // Last byte must always be the NUL terminator, even if the message
-            // doesn't fit into the buffer.
-            debug_assert_eq!(msg_buffer.last(), Some(&0));
-            if msg_buffer.len() < FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN {
-                // Allocate larger buffer and try again.
-                msg_buffer.resize(FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN, 0);
-                continue;
-            }
-            // Message is too large to format. Truncate the message by ending it with `...`.
-            for char in msg_buffer.iter_mut().rev().skip(1).take(3) {
-                *char = b'.';
-            }
-        } else {
-            // Message fits into the buffer. Make sure that `from_bytes_with_nul()`
-            // sees the expected single NUL terminator in the final position.
-            msg_buffer.truncate(buffer_len);
-        }
-        break;
-    }
-
-    // Free the `va_list` argument that is not consumed by `vsnprintf()`!
-    unsafe { vsnprintf_va_end(args) }
-
-    // Last byte must always be the NUL terminator.
-    debug_assert_eq!(msg_buffer.last(), Some(&0));
-
-    Some(msg_buffer)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,17 +88,18 @@ mod callback;
 mod userdata;
 mod value;
 
+pub(crate) use self::{
+    client::client_logger,
+    data_type::{data_type, enum_variants},
+    service::{ServiceRequest, ServiceResponse},
+    value::{ArrayValue, NonScalarValue},
+};
 pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
     error::{Error, Result},
     userdata::Userdata,
     value::{ScalarValue, ValueType, VariantValue},
-};
-pub(crate) use self::{
-    data_type::{data_type, enum_variants},
-    service::{ServiceRequest, ServiceResponse},
-    value::{ArrayValue, NonScalarValue},
 };
 
 #[cfg(feature = "tokio")]

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -2,6 +2,7 @@
 
 mod array;
 mod client;
+mod client_config;
 mod continuation_point;
 mod data_types;
 mod monitored_item_id;
@@ -10,6 +11,7 @@ mod secure_channel_state;
 mod session_state;
 mod subscription_id;
 
+pub(crate) use self::client_config::ClientConfig;
 pub use self::{
     array::Array,
     client::{Client, ClientState},

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -2,6 +2,7 @@ use std::ptr::NonNull;
 
 use open62541_sys::{
     UA_Client, UA_Client_delete, UA_Client_disconnect, UA_Client_getState, UA_Client_new,
+    UA_Client_newWithConfig,
 };
 
 use crate::{ua, DataType as _, Error};
@@ -30,6 +31,18 @@ pub struct Client(NonNull<UA_Client>);
 unsafe impl Send for Client {}
 
 impl Client {
+    /// Creates client from client config.
+    ///
+    /// This consumes the config object and makes the client the owner of all contained data therein
+    /// (e.g. logging configuration and logger instance).
+    pub(crate) fn new_with_config(config: ua::ClientConfig) -> Self {
+        let config = config.into_raw();
+        let inner = unsafe { UA_Client_newWithConfig(&config) };
+        // PANIC: The only possible errors here are out-of-memory.
+        let inner = NonNull::new(inner).expect("create new UA_Client");
+        Self(inner)
+    }
+
     /// Returns const pointer to value.
     ///
     /// # Safety

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -39,7 +39,7 @@ impl Client {
         let config = config.into_raw();
         let inner = unsafe { UA_Client_newWithConfig(&config) };
         // PANIC: The only possible errors here are out-of-memory.
-        let inner = NonNull::new(inner).expect("create new UA_Client");
+        let inner = NonNull::new(inner).expect("create UA_Client");
         Self(inner)
     }
 
@@ -117,7 +117,7 @@ impl Default for Client {
     /// Creates wrapper initialized with defaults.
     fn default() -> Self {
         // `UA_Client_new()` matches `UA_Client_delete()`.
-        let inner = NonNull::new(unsafe { UA_Client_new() }).expect("create new UA_Client");
+        let inner = NonNull::new(unsafe { UA_Client_new() }).expect("create UA_Client");
         Self(inner)
     }
 }

--- a/src/ua/client_config.rs
+++ b/src/ua/client_config.rs
@@ -1,0 +1,254 @@
+use std::{
+    ffi::{c_void, CStr},
+    mem::MaybeUninit,
+    os::raw::c_char,
+    ptr,
+};
+
+use open62541_sys::{
+    vsnprintf_va_copy, vsnprintf_va_end, UA_ClientConfig, UA_ClientConfig_clear,
+    UA_ClientConfig_setDefault, UA_LogCategory, UA_LogLevel, UA_Logger,
+};
+
+use crate::{ua, Error};
+
+pub(crate) struct ClientConfig(Option<UA_ClientConfig>);
+
+impl ClientConfig {
+    /// Creates wrapper by taking ownership of value.
+    ///
+    /// When `Self` is dropped, allocations held by the inner type are cleaned up.
+    ///
+    /// # Safety
+    ///
+    /// Ownership of the value passes to `Self`. This must only be used for values that are not
+    /// contained within other values that may be dropped.
+    #[must_use]
+    pub(crate) const unsafe fn from_raw(src: UA_ClientConfig) -> Self {
+        Self(Some(src))
+    }
+
+    /// Gives up ownership and returns value.
+    ///
+    /// The returned value must be re-wrapped with [`from_raw()`], cleared manually, or copied into
+    /// an owning value (like [`UA_Client`]) to free internal allocations and not leak memory.
+    ///
+    /// [`from_raw()`]: Self::from_raw
+    /// [`UA_Client`]: open62541_sys::UA_Client
+    #[must_use]
+    pub(crate) fn into_raw(mut self) -> UA_ClientConfig {
+        self.0.take().expect("should have client config")
+    }
+
+    /// Creates wrapper initialized with defaults.
+    ///
+    /// This initializes the value and makes all attributes well-defined. Additional attributes may
+    /// need to be initialized for the value to be actually useful afterwards.
+    pub(crate) const fn init() -> Self {
+        let inner = MaybeUninit::<UA_ClientConfig>::zeroed();
+        // SAFETY: Zero-initialized memory is a valid client config.
+        let inner = unsafe { inner.assume_init() };
+        // SAFETY: We pass a value without pointers to it into `Self`.
+        unsafe { Self::from_raw(inner) }
+    }
+
+    /// Returns exclusive reference to value.
+    ///
+    /// # Safety
+    ///
+    /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
+    /// may happen when `open62541` functions are called that take ownership of values by pointer.
+    #[must_use]
+    pub(crate) unsafe fn as_mut(&mut self) -> &mut UA_ClientConfig {
+        // PANIC: The inner object can only be unset when ownership has been given away.
+        self.0.as_mut().expect("should have client config")
+    }
+
+    /// Returns mutable pointer to value.
+    ///
+    /// # Safety
+    ///
+    /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
+    /// may happen when `open62541` functions are called that take ownership of values by pointer.
+    #[must_use]
+    pub(crate) unsafe fn as_mut_ptr(&mut self) -> *mut UA_ClientConfig {
+        // PANIC: The inner object can only be unset when ownership has been given away.
+        self.0.as_mut().expect("should have client config")
+    }
+}
+
+impl Drop for ClientConfig {
+    fn drop(&mut self) {
+        // Check if we still hold the client config. If not, we must not clean up: the ownership has
+        // passed to the client that was created from this config.
+        let Some(mut inner) = self.0.take() else {
+            return;
+        };
+
+        // Clean up held resources such as logging configuration.
+        unsafe { UA_ClientConfig_clear(&mut inner) }
+    }
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        let mut config = Self::init();
+
+        // First set custom logger. This is necessary because the same logger instance is used as-is
+        // inside derived attributes such as `eventLoop`, `certificateVerification`, etc.
+        set_default_logger(unsafe { config.as_mut() });
+
+        // Set remaining attributes to their default values. This also copies the logger as laid out
+        // above.
+        let status_code =
+            ua::StatusCode::new(unsafe { UA_ClientConfig_setDefault(config.as_mut_ptr()) });
+        // PANIC: The only possible errors here are out-of-memory.
+        Error::verify_good(&status_code).expect("should be able to set default client config");
+
+        config
+    }
+}
+
+/// Installs logger that forwards to the `log` crate.
+///
+/// This remove an existing logger from the given configuration (by calling its `clear()` callback),
+/// then installs a custom logger that forwards all messages to the corresponding calls in the `log`
+/// crate.
+///
+/// We can use this to prevent `open62541` from installing its own default logger (which outputs any
+/// logs to stdout/stderr directly).
+fn set_default_logger(config: &mut UA_ClientConfig) {
+    unsafe extern "C" fn log_c(
+        _log_context: *mut c_void,
+        level: UA_LogLevel,
+        _category: UA_LogCategory,
+        msg: *const c_char,
+        args: open62541_sys::va_list_,
+    ) {
+        let Some(msg) = format_message(msg, args) else {
+            log::error!(target: "open62541::client", "Unknown log message");
+            return;
+        };
+
+        let msg = CStr::from_bytes_with_nul(&msg)
+            .expect("string length should match")
+            .to_string_lossy();
+
+        if level == UA_LogLevel::UA_LOGLEVEL_FATAL {
+            // Without fatal level in `log`, fall back to error.
+            log::error!(target: "open62541::client", "{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_ERROR {
+            log::error!(target: "open62541::client", "{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_WARNING {
+            log::warn!(target: "open62541::client", "{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_INFO {
+            log::info!(target: "open62541::client", "{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_DEBUG {
+            log::debug!(target: "open62541::client", "{msg}");
+        } else if level == UA_LogLevel::UA_LOGLEVEL_TRACE {
+            log::trace!(target: "open62541::client", "{msg}");
+        } else {
+            // Handle unexpected level by escalating to error.
+            log::error!(target: "open62541::client", "{msg}");
+        }
+    }
+
+    unsafe extern "C" fn clear_c(logger: *mut UA_Logger) {
+        // This consumes the `UA_Logger` structure itself, invalidating the pointer `config.logging`
+        // and thereby releasing all allocated resources.
+        //
+        // This is in line with the contract that `config.logging` may not be used anymore after its
+        // `clear()` method has been called.
+        let logger = unsafe { Box::from_raw(logger) };
+
+        // Run some sanity checks. We should only ever be called on our own data structure.
+        debug_assert!(logger.log == Some(log_c));
+        debug_assert!(logger.clear == Some(clear_c));
+
+        // As long as we do not carry data, there is nothing to clean up here.
+        debug_assert!(logger.context.is_null());
+
+        // Dropping the boxed logger cleans up allocated memory.
+        drop(logger);
+    }
+
+    // This function should only be called on default-initialized config objects. The reason is that
+    // we do not know whether the `logging` configuration is still referenced somewhere else.
+    assert!(config.logging.is_null());
+
+    // Create logger configuration. We leak the memory which is cleaned up eventually when `clear()`
+    // is called (which is `clear_c()` above).
+    config.logging = Box::leak(Box::new(UA_Logger {
+        log: Some(log_c),
+        context: ptr::null_mut(),
+        clear: Some(clear_c),
+    }));
+}
+
+/// Initial buffer size when formatting messages.
+const FORMAT_MESSAGE_DEFAULT_BUFFER_LEN: usize = 128;
+
+/// Maximum buffer size when formatting messages.
+const FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN: usize = 65536;
+
+/// Formats message with `vprintf` library calls.
+///
+/// This returns the formatted message with a trailing NUL byte, or `None` when formatting fails. A
+/// long message may be truncated (see [`FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN`] for details); its last
+/// characters will be replaced with `...` to indicate this.
+fn format_message(msg: *const c_char, args: open62541_sys::va_list_) -> Option<Vec<u8>> {
+    // Delegate string formatting to `vsnprintf()`, the length-checked string buffer variant of the
+    // variadic `vprintf` family.
+    //
+    // We use the custom `vsnprintf_va_copy()` provided by `open62541_sys`. This copies the va args
+    // and requires an explicit call to `vsnprintf_va_end()` afterwards.
+
+    // Allocate default buffer first. Only when the message doesn't fit, we need to allocate larger
+    // buffer below.
+    let mut msg_buffer: Vec<u8> = vec![0; FORMAT_MESSAGE_DEFAULT_BUFFER_LEN];
+    loop {
+        let result = unsafe {
+            vsnprintf_va_copy(
+                msg_buffer.as_mut_ptr().cast::<c_char>(),
+                msg_buffer.len(),
+                msg,
+                args,
+            )
+        };
+        let Ok(msg_len) = usize::try_from(result) else {
+            // Negative result is an error in the format string. Nothing we can do.
+            debug_assert!(result < 0);
+            // Free the `va_list` argument that is no consumed by `vsnprintf()`!
+            unsafe { vsnprintf_va_end(args) }
+            return None;
+        };
+        let buffer_len = msg_len + 1;
+        if buffer_len > msg_buffer.len() {
+            // Last byte must always be the NUL terminator, even if the message
+            // doesn't fit into the buffer.
+            debug_assert_eq!(msg_buffer.last(), Some(&0));
+            if msg_buffer.len() < FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN {
+                // Allocate larger buffer and try again.
+                msg_buffer.resize(FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN, 0);
+                continue;
+            }
+            // Message is too large to format. Truncate the message by ending it with `...`.
+            for char in msg_buffer.iter_mut().rev().skip(1).take(3) {
+                *char = b'.';
+            }
+        } else {
+            // Message fits into the buffer. Make sure that `from_bytes_with_nul()`
+            // sees the expected single NUL terminator in the final position.
+            msg_buffer.truncate(buffer_len);
+        }
+        break;
+    }
+
+    // Free the `va_list` argument that is not consumed by `vsnprintf()`!
+    unsafe { vsnprintf_va_end(args) }
+
+    // Last byte must always be the NUL terminator.
+    debug_assert_eq!(msg_buffer.last(), Some(&0));
+
+    Some(msg_buffer)
+}

--- a/src/ua/client_config.rs
+++ b/src/ua/client_config.rs
@@ -1,14 +1,6 @@
-use std::{
-    ffi::{c_void, CStr},
-    mem::MaybeUninit,
-    os::raw::c_char,
-    ptr,
-};
+use std::mem::MaybeUninit;
 
-use open62541_sys::{
-    vsnprintf_va_copy, vsnprintf_va_end, UA_ClientConfig, UA_ClientConfig_clear,
-    UA_ClientConfig_setDefault, UA_LogCategory, UA_LogLevel, UA_Logger,
-};
+use open62541_sys::{UA_ClientConfig, UA_ClientConfig_clear, UA_ClientConfig_setDefault};
 
 use crate::{ua, Error};
 
@@ -79,14 +71,11 @@ impl ClientConfig {
 
 impl Drop for ClientConfig {
     fn drop(&mut self) {
-        // Check if we still hold the client config. If not, we must not clean up: the ownership has
+        // Check if we still hold the client config. If not, we need not clean up: the ownership has
         // passed to the client that was created from this config.
-        let Some(mut inner) = self.0.take() else {
-            return;
-        };
-
-        // Clean up held resources such as logging configuration.
-        unsafe { UA_ClientConfig_clear(&mut inner) }
+        if let Some(mut inner) = self.0.take() {
+            unsafe { UA_ClientConfig_clear(&mut inner) }
+        }
     }
 }
 
@@ -94,17 +83,17 @@ impl Default for ClientConfig {
     fn default() -> Self {
         let mut config = Self::init();
 
-        // First set custom logger. This is necessary because the same logger instance is used as-is
+        // Set custom logger first. This is necessary because the same logger instance is used as-is
         // inside derived attributes such as `eventLoop`, `certificateVerification`, etc.
         {
             let config = unsafe { config.as_mut() };
-            // We set the logging only on default-initialized config objects: we cannot know whether
+            // We assign a logger only on default-initialized config objects: we cannot know whether
             // an existing configuration is still referenced in another attribute or structure, thus
-            // we would not be allowed to free it.
+            // we could not (safely) free it anyway.
             debug_assert!(config.logging.is_null());
             // Create logger configuration. Ownership of the `UA_Logger` instance passes to `config`
             // at this point.
-            config.logging = client_logger();
+            config.logging = crate::client_logger();
         }
 
         // Set remaining attributes to their default values. This also copies the logger as laid out
@@ -112,145 +101,8 @@ impl Default for ClientConfig {
         let status_code =
             ua::StatusCode::new(unsafe { UA_ClientConfig_setDefault(config.as_mut_ptr()) });
         // PANIC: The only possible errors here are out-of-memory.
-        Error::verify_good(&status_code).expect("should be able to set default client config");
+        Error::verify_good(&status_code).expect("should set default client config");
 
         config
     }
-}
-
-/// Creates logger that forwards to the `log` crate.
-///
-/// We can use this to prevent `open62541` from installing its own default logger (which outputs any
-/// logs to stdout/stderr directly).
-///
-/// Note that this leaks memory unless the returned pointer is assigned to `UA_ClientConfig` (and/or
-/// `UA_Client` in turn), eventually calling `UA_Logger::clear()` with the `UA_Logger` instance.
-fn client_logger() -> *mut UA_Logger {
-    unsafe extern "C" fn log_c(
-        _log_context: *mut c_void,
-        level: UA_LogLevel,
-        _category: UA_LogCategory,
-        msg: *const c_char,
-        args: open62541_sys::va_list_,
-    ) {
-        let Some(msg) = format_message(msg, args) else {
-            log::error!(target: "open62541::client", "Unknown log message");
-            return;
-        };
-
-        let msg = CStr::from_bytes_with_nul(&msg)
-            .expect("string length should match")
-            .to_string_lossy();
-
-        if level == UA_LogLevel::UA_LOGLEVEL_FATAL {
-            // Without fatal level in `log`, fall back to error.
-            log::error!(target: "open62541::client", "{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_ERROR {
-            log::error!(target: "open62541::client", "{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_WARNING {
-            log::warn!(target: "open62541::client", "{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_INFO {
-            log::info!(target: "open62541::client", "{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_DEBUG {
-            log::debug!(target: "open62541::client", "{msg}");
-        } else if level == UA_LogLevel::UA_LOGLEVEL_TRACE {
-            log::trace!(target: "open62541::client", "{msg}");
-        } else {
-            // Handle unexpected level by escalating to error.
-            log::error!(target: "open62541::client", "{msg}");
-        }
-    }
-
-    unsafe extern "C" fn clear_c(logger: *mut UA_Logger) {
-        // This consumes the `UA_Logger` structure itself, invalidating the pointer `config.logging`
-        // and thereby releasing all allocated resources.
-        //
-        // This is in line with the contract that `config.logging` may not be used anymore after its
-        // `clear()` method has been called.
-        let logger = unsafe { Box::from_raw(logger) };
-
-        // Run some sanity checks. We should only ever be called on our own data structure.
-        debug_assert!(logger.log == Some(log_c));
-        debug_assert!(logger.clear == Some(clear_c));
-
-        // As long as we do not carry data, there is nothing to clean up here.
-        debug_assert!(logger.context.is_null());
-
-        // Dropping the boxed logger cleans up allocated memory.
-        drop(logger);
-    }
-
-    Box::leak(Box::new(UA_Logger {
-        log: Some(log_c),
-        context: ptr::null_mut(),
-        clear: Some(clear_c),
-    }))
-}
-
-/// Initial buffer size when formatting messages.
-const FORMAT_MESSAGE_DEFAULT_BUFFER_LEN: usize = 128;
-
-/// Maximum buffer size when formatting messages.
-const FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN: usize = 65536;
-
-/// Formats message with `vprintf` library calls.
-///
-/// This returns the formatted message with a trailing NUL byte, or `None` when formatting fails. A
-/// long message may be truncated (see [`FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN`] for details); its last
-/// characters will be replaced with `...` to indicate this.
-fn format_message(msg: *const c_char, args: open62541_sys::va_list_) -> Option<Vec<u8>> {
-    // Delegate string formatting to `vsnprintf()`, the length-checked string buffer variant of the
-    // variadic `vprintf` family.
-    //
-    // We use the custom `vsnprintf_va_copy()` provided by `open62541_sys`. This copies the va args
-    // and requires an explicit call to `vsnprintf_va_end()` afterwards.
-
-    // Allocate default buffer first. Only when the message doesn't fit, we need to allocate larger
-    // buffer below.
-    let mut msg_buffer: Vec<u8> = vec![0; FORMAT_MESSAGE_DEFAULT_BUFFER_LEN];
-    loop {
-        let result = unsafe {
-            vsnprintf_va_copy(
-                msg_buffer.as_mut_ptr().cast::<c_char>(),
-                msg_buffer.len(),
-                msg,
-                args,
-            )
-        };
-        let Ok(msg_len) = usize::try_from(result) else {
-            // Negative result is an error in the format string. Nothing we can do.
-            debug_assert!(result < 0);
-            // Free the `va_list` argument that is no consumed by `vsnprintf()`!
-            unsafe { vsnprintf_va_end(args) }
-            return None;
-        };
-        let buffer_len = msg_len + 1;
-        if buffer_len > msg_buffer.len() {
-            // Last byte must always be the NUL terminator, even if the message
-            // doesn't fit into the buffer.
-            debug_assert_eq!(msg_buffer.last(), Some(&0));
-            if msg_buffer.len() < FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN {
-                // Allocate larger buffer and try again.
-                msg_buffer.resize(FORMAT_MESSAGE_MAXIMUM_BUFFER_LEN, 0);
-                continue;
-            }
-            // Message is too large to format. Truncate the message by ending it with `...`.
-            for char in msg_buffer.iter_mut().rev().skip(1).take(3) {
-                *char = b'.';
-            }
-        } else {
-            // Message fits into the buffer. Make sure that `from_bytes_with_nul()`
-            // sees the expected single NUL terminator in the final position.
-            msg_buffer.truncate(buffer_len);
-        }
-        break;
-    }
-
-    // Free the `va_list` argument that is not consumed by `vsnprintf()`!
-    unsafe { vsnprintf_va_end(args) }
-
-    // Last byte must always be the NUL terminator.
-    debug_assert_eq!(msg_buffer.last(), Some(&0));
-
-    Some(msg_buffer)
 }


### PR DESCRIPTION
## Description

This fixes an edge case in the initialization of our `log` integration.

Previously, only a single copy of `UA_Logger` would be used inside `UA_ClientConfig`. With open62541 1.4, the same logger instance is used in several attributes, such as `eventLoop`, which are set up by [`UA_ClientConfig_setDefault()`](https://github.com/open62541/open62541/blob/ddddcf2cf1a2c2b9700d6d853843bf8f78874f2d/plugins/ua_config_default.c#L272). When we cleaned up the existing default stdout/stderr logger, we failed to consider such copies inside of these additional attributes, resulting in a client config with two _different_ loggers, one of which was half-destructed by us.

Fixes #85