### PR TITLE
Upgrade to latest open62541-sys version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.0-pre.2"
+version = "0.4.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e27ab1f771a76c754f6f09e5784e3470147f3f0099983e8fd3e0cbe37a23d0"
+checksum = "dd784b8e2a942be3a929e0c8083bd8ce057174f3b6c1521749af2d30c220f1b6"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.0-pre.2"
+open62541-sys = "0.4.0-pre.3"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest [release](https://github.com/HMIProject/open62541-sys/releases/tag/v0.4.0-pre.3) of open62541-sys.