### PR TITLE
Fix regression when decoding method arguments in open62541 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Remove `ua::ArrayValue` for now (until we have a better interface).
 - Breaking: Return output arguments directly from `AsyncClient::call_method()`, without `Option`.
 - Breaking: Remove misleading `FromStr` trait implementation and offer `ua::String::new()` instead.
-- Upgrade to open62541 version 1.4. By itself, this should not affect the public API of this crate.
+- Breaking: Upgrade to open62541 version 1.4. This affects the public API of this crate as follows:
+  - Automatically unwrap `ua::ExtensionObject` arrays inside `ua::Variant`.
 
 ### Fixed
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -174,18 +174,13 @@ fn get_arguments(value: &ua::DataValue) -> anyhow::Result<Vec<(ua::String, Value
     let arguments = value
         .value()
         .ok_or(anyhow::anyhow!("should have value"))?
-        .to_array::<ua::ExtensionObject>()
+        .to_array::<ua::Argument>()
         .ok_or(anyhow::anyhow!("should have array"))?;
 
-    arguments
+    Ok(arguments
         .iter()
-        .map(|object| {
-            let argument = object
-                .decoded_content::<ua::Argument>()
-                .ok_or(anyhow::anyhow!("should have argument"))?;
-            Ok((argument.name().clone(), argument.value_type()))
-        })
-        .collect()
+        .map(|argument| (argument.name().clone(), argument.value_type()))
+        .collect())
 }
 
 /// Gets name of referenced property.


### PR DESCRIPTION
## Description

In open62541 1.4, a Variant that holds an array of a specific data type is directly resolved to that data type, instead of going through ExtensionObject. See [open62541 release notes](https://github.com/open62541/open62541/releases/tag/v1.4.0-rc1).

This affects how we parse method arguments in the `async_call` example.