### PR TITLE
Remove cycle time from public interface

### DIFF
--- a/examples/async_browse.rs
+++ b/examples/async_browse.rs
@@ -7,14 +7,11 @@ use anyhow::Context as _;
 use open62541::{ua, AsyncClient, DataType as _, Result};
 use open62541_sys::UA_NS0ID_SERVERTYPE;
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-        .context("connect")?;
+    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
     let hierarchy = browse_hierarchy(&client, &ua::NodeId::numeric(0, UA_NS0ID_SERVERTYPE)).await?;
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -2,14 +2,11 @@ use anyhow::{anyhow, Context as _};
 use open62541::{ua, AsyncClient, DataType as _, ValueType};
 use open62541_sys::{UA_NS0ID_HASPROPERTY, UA_NS0ID_PROPERTYTYPE};
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-        .context("connect")?;
+    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
     // `/Root/Objects/10:Simulation/10:ObjectWithMethods`
     let object_node_id = ua::NodeId::string(10, "ObjectWithMethods");

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -11,14 +11,11 @@ use open62541_sys::{
 };
 use tokio::time;
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-        .context("connect")?;
+    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
     println!("Connected successfully");
 

--- a/examples/async_client_builder.rs
+++ b/examples/async_client_builder.rs
@@ -1,8 +1,6 @@
 use anyhow::Context as _;
 use open62541::{ua, ClientBuilder, DataType as _};
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -19,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
         .client_description(client_description)
         .connect("opc.tcp://opcuademo.sterfive.com:26543")
         .context("connect")?
-        .into_async(CYCLE_TIME);
+        .into_async();
 
     println!("Connected successfully");
 

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -8,18 +8,14 @@ use open62541_sys::{
 use rand::Rng as _;
 use tokio::time::error::Elapsed;
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     println!("Connecting client");
 
-    let client = Arc::new(
-        AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-            .context("connect")?,
-    );
+    let client =
+        Arc::new(AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?);
 
     println!("Creating subscription");
 

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -4,8 +4,6 @@ use anyhow::Context as _;
 use open62541::{ua, AsyncClient, DataType};
 use rand::Rng as _;
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 const ATTRIBUTE_IDS: [ua::AttributeId; 11] = [
     ua::AttributeId::NODEID,
     ua::AttributeId::NODECLASS,
@@ -24,8 +22,7 @@ const ATTRIBUTE_IDS: [ua::AttributeId; 11] = [
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-        .context("connect")?;
+    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
     // `/Root/Objects/2:DeviceSet/1:CoffeeMachine/1:Espresso/7:BeverageSize`
     let float_node_id = ua::NodeId::numeric(1, 1074);

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -6,14 +6,11 @@ use open62541::{ua, AsyncClient};
 use open62541_sys::UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME;
 use tokio::task;
 
-const CYCLE_TIME: tokio::time::Duration = tokio::time::Duration::from_millis(100);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543", CYCLE_TIME)
-        .context("connect")?;
+    let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
     println!("Client connected successfully");
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -29,7 +29,7 @@ use crate::{
 /// Since this is also the timeout we must block for when dropping the client without `disconnect()`
 /// first, the value should not be too large. On the other hand, it should not be too small to avoid
 /// repeatedly calling `poll()`/`select()` inside open62541's event loop implementation.
-const ITERATION_TIMEOUT: Duration = Duration::from_millis(500);
+const RUN_ITERATE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Connected OPC UA client (with asynchronous API).
 ///
@@ -69,7 +69,7 @@ impl AsyncClient {
         let background_canceled = Arc::new(AtomicBool::new(false));
 
         // Run the event loop concurrently. We do so on a thread where we may block: we need to call
-        // `UA_Client_run_iterate()` and this method blocks for up to `ITERATION_TIMEOUT` each time.
+        // `UA_Client_run_iterate()` and this method blocks for up to `RUN_ITERATE_TIMEOUT`.
         //
         // We use an OS thread here instead of tokio's blocking tasks because we may need to join on
         // the task blockingly in `drop()` and this requires proper concurrency (otherwise, we would
@@ -465,15 +465,15 @@ impl Drop for AsyncClient {
 
 /// Background task for [`ua::Client`].
 ///
-/// This runs [`UA_Client_run_iterate()`] in a loop (and blocks for up to `ITERATION_TIMEOUT` during
-/// each iteration). In case the loop does not finish by itself (which happens in case of disconnect
+/// This runs [`UA_Client_run_iterate()`] in a loop, blocking for up to `RUN_ITERATE_TIMEOUT` during
+/// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
 /// and for final connection failures), the cancellation token `cancel` can be used to stop the task
 /// from the outside before the next loop iteration.
 fn background_task(client: &ua::Client, canceled: &AtomicBool) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.
-    let timeout_millis = u32::try_from(ITERATION_TIMEOUT.as_millis()).unwrap_or(u32::MAX);
+    let timeout_millis = u32::try_from(RUN_ITERATE_TIMEOUT.as_millis()).unwrap_or(u32::MAX);
 
     // Run until canceled. The only other way to exit is when `UA_Client_run_iterate()` itself fails
     // (which happens when the connection is broken and the client instance cannot be used anymore).

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -29,7 +29,7 @@ use crate::{
 /// Since this is also the timeout we must block for when dropping the client without `disconnect()`
 /// first, the value should not be too large. On the other hand, it should not be too small to avoid
 /// repeatedly calling `poll()`/`select()` inside open62541's event loop implementation.
-const ITERATION_TIMEOUT: Duration = Duration::from_millis(100);
+const ITERATION_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Connected OPC UA client (with asynchronous API).
 ///

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -459,7 +459,7 @@ impl Drop for AsyncClient {
 /// This runs [`UA_Client_run_iterate()`] repeatedly, and may block for up to `cycle_time`. When the
 /// loop does not finish by itself (which happens for disconnect, and for final connection failure),
 /// the cancellation token `cancel` can be used to stop the task before the next loop iteration.
-fn background_task(client: &Arc<ua::Client>, cycle_time: Duration, canceled: &Arc<AtomicBool>) {
+fn background_task(client: &ua::Client, cycle_time: Duration, canceled: &AtomicBool) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.

--- a/src/client.rs
+++ b/src/client.rs
@@ -180,14 +180,11 @@ impl Client {
     ///
     /// The [`AsyncClient`] can be used to access methods in an asynchronous way.
     ///
-    /// `cycle_time` controls the frequency at which the client will poll the server for responses
-    /// in the background.
-    ///
     /// [`AsyncClient`]: crate::AsyncClient
     #[cfg(feature = "tokio")]
     #[must_use]
-    pub fn into_async(self, cycle_time: tokio::time::Duration) -> crate::AsyncClient {
-        crate::AsyncClient::from_sync(self.0, cycle_time)
+    pub fn into_async(self) -> crate::AsyncClient {
+        crate::AsyncClient::from_sync(self.0)
     }
 
     /// Gets current channel and session state, and connect status.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,7 @@
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
-//! let client = AsyncClient::new(
-//!     "opc.tcp://opcuademo.sterfive.com:26543",
-//!     tokio::time::Duration::from_millis(100),
-//! )?;
+//! let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;
 //! #
 //! # Ok(())
 //! # }
@@ -28,10 +25,7 @@
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
-//! # let client = AsyncClient::new(
-//! #     "opc.tcp://opcuademo.sterfive.com:26543",
-//! #     tokio::time::Duration::from_millis(100),
-//! # )?;
+//! # let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;
 //! #
 //! let node_id = NodeId::numeric(0, 2258); // Server/ServerStatus/CurrentTime
 //!
@@ -51,10 +45,7 @@
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
-//! # let client = AsyncClient::new(
-//! #     "opc.tcp://opcuademo.sterfive.com:26543",
-//! #     tokio::time::Duration::from_millis(100),
-//! # )?;
+//! # let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;
 //! #
 //! # let node_id = NodeId::numeric(0, 2258); // Server/ServerStatus/CurrentTime
 //! #


### PR DESCRIPTION
## Description

As hinted at in https://github.com/HMIProject/open62541/pull/90#issuecomment-2039502774, this removes the `cycle_time` argument from the public interface of `AsyncClient`.

It is no longer necessary and can be regarded as an implementation detail: where before this was effectively the polling interval of handling queued server responses, i.e. the interval we call `UA_Client_run_iterate()` at, the only user-facing aspect now is the maximum delay we can expect when dropping a client without calling `disconnect()` first (which should be avoided anyway).

In other words, the cycle time or iteration timeout only controls the frequency of cancellation points in our background task: each invocation of `UA_Client_run_iterate()` blocks and we only must make sure to wake up frequently enough to be able to interrupt this background loop when being dropped without `disconnect()`.

Since we can provide a sane default value, this lowers the threshold when developers first start to work with `AsyncClient`. If we want to allow fine-tuned values for different environments in the future, we could make this parameter configurable through `ClientBuilder`.