### PR TITLE
Split server type to allow mutations while running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Breaking: Remove associated functions for enum data types deprecated in 0.5.0, e.g.
   `ua::AttributedId::value()`. Use uppercase constants `ua::AttributedId::VALUE` instead.
+- Breaking: Split `Server::new()` and `ServerBuilder::build()` result type into `Server` and
+  `ServerRunner` to allow interacting with server's data tree while server is running.
 
 ## [0.6.0-pre.2] - 2024-04-12
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -13,7 +13,7 @@ use open62541_sys::{
 fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let (mut server, runner) = Server::new();
+    let (server, runner) = Server::new();
 
     println!("Adding server nodes");
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,3 +1,9 @@
+use std::{
+    sync::mpsc::{self, RecvTimeoutError},
+    thread,
+    time::Duration,
+};
+
 use open62541::{ua, ObjectNode, Server, VariableNode};
 use open62541_sys::{
     UA_NS0ID_BASEDATAVARIABLETYPE, UA_NS0ID_FOLDERTYPE, UA_NS0ID_OBJECTSFOLDER, UA_NS0ID_ORGANIZES,
@@ -7,7 +13,7 @@ use open62541_sys::{
 fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let mut server = Server::new();
+    let (mut server, runner) = Server::new();
 
     println!("Adding server nodes");
 
@@ -36,11 +42,53 @@ fn main() -> anyhow::Result<()> {
 
     server.write_variable_string(&variable_node_id, "foobar")?;
 
-    println!("Running server");
+    let (cancel_tx, cancel_rx) = mpsc::channel();
 
-    server.run()?;
+    // Start background task that simulates changing variable values.
+    let server_task_handle = thread::spawn(move || -> anyhow::Result<()> {
+        println!("Simulating values");
+        loop {
+            for value in ["foo", "bar", "baz"] {
+                match cancel_rx.recv_timeout(Duration::from_millis(1000)) {
+                    Ok(()) => return Ok(()),
+                    Err(RecvTimeoutError::Timeout) => {
+                        // Continue and simulate next updated value below, then repeat loop.
+                    }
+                    Err(RecvTimeoutError::Disconnected) => panic!("main task should be running"),
+                }
+                server.write_variable_string(&variable_node_id, value)?;
+            }
+        }
+    });
+
+    // Start runner task that handles incoming connections (events).
+    let runner_task_handle = thread::spawn(|| -> anyhow::Result<()> {
+        println!("Running server");
+        runner.run()?;
+        Ok(())
+    });
+
+    // Wait for runner task to finish eventually (SIGINT/Ctrl+C).
+    if let Err(err) = runner_task_handle
+        .join()
+        .expect("runner task should not panic")
+    {
+        println!("Runner task failed: {err}");
+    }
 
     println!("Exiting");
+
+    cancel_tx.send(()).expect("server task should be running");
+
+    // Wait for simulation task to shut down after canceling.
+    if let Err(err) = server_task_handle
+        .join()
+        .expect("server task should not panic")
+    {
+        println!("Server task failed: {err}");
+    }
+
+    println!("Done");
 
     Ok(())
 }

--- a/examples/server_builder.rs
+++ b/examples/server_builder.rs
@@ -5,11 +5,11 @@ fn main() -> anyhow::Result<()> {
 
     println!("Building server");
 
-    let server = ServerBuilder::default().port(4841).build();
+    let (_, runner) = ServerBuilder::default().port(4841).build();
 
     println!("Running server");
 
-    server.run()?;
+    runner.run()?;
 
     println!("Exiting");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
     error::{Error, Result},
-    server::{Server, ServerBuilder},
+    server::{Server, ServerBuilder, ServerRunner},
     server_nodes::{ObjectNode, VariableNode},
     userdata::Userdata,
     value::{ScalarValue, ValueType, VariantValue},

--- a/src/server.rs
+++ b/src/server.rs
@@ -77,8 +77,8 @@ impl ServerBuilder {
 ///
 /// This represents an OPC UA server. Nodes can be added through the several methods below.
 ///
-/// Note: The server must be started with [`ServerRunner::run()`] before it is actually visible to
-/// external clients.
+/// Note: The server must be started with [`ServerRunner::run()`] before it can accept connections
+/// from clients.
 pub struct Server(Arc<ua::Server>);
 
 impl Server {

--- a/src/server.rs
+++ b/src/server.rs
@@ -79,6 +79,7 @@ impl ServerBuilder {
 ///
 /// Note: The server must be started with [`ServerRunner::run()`] before it can accept connections
 /// from clients.
+#[derive(Clone)]
 pub struct Server(Arc<ua::Server>);
 
 impl Server {

--- a/src/ua/server.rs
+++ b/src/ua/server.rs
@@ -10,6 +10,14 @@ use crate::{ua, Error};
 /// [`UA_Server_delete()`].
 pub struct Server(NonNull<UA_Server>);
 
+// SAFETY: We know that the underlying `UA_Server` allows access from different threads, i.e. it may
+// be dropped in a different thread from where it was created.
+unsafe impl Send for Server {}
+
+// SAFETY: The underlying `UA_Server` can be used from different threads concurrently, at least with
+// _most_ methods (those marked `UA_THREADSAFE` and/or with explicit mutex locks inside).
+unsafe impl Sync for Server {}
+
 impl Server {
     /// Creates server from server config.
     ///

--- a/src/ua/server.rs
+++ b/src/ua/server.rs
@@ -50,7 +50,7 @@ impl Server {
     /// The value is owned by `Self`. Ownership must not be given away, in whole or in parts. This
     /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[must_use]
-    pub(crate) const unsafe fn as_mut_ptr(&self) -> *mut UA_Server {
+    pub(crate) unsafe fn as_mut_ptr(&mut self) -> *mut UA_Server {
         self.0.as_ptr()
     }
 }


### PR DESCRIPTION
## Description

This PR splits the `Server` type into `Server` and `ServerRunner`.[^1] The latter handles the server's event loop (and is consumed) while the former can be used to modify variable values from different threads while the server is running.

[^1]: Feel free to suggest better names.