### PR TITLE
Upgrade to released version 1.4.0 of open62541

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Breaking: Remove associated functions for enum data types deprecated in 0.5.0, e.g.
   `ua::AttributedId::value()`. Use uppercase constants `ua::AttributedId::VALUE` instead.
+- Upgrade to open62541 released version 1.4.0.
 
 ## [0.6.0-pre.2] - 2024-04-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.0-pre.3"
+version = "0.4.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd784b8e2a942be3a929e0c8083bd8ce057174f3b6c1521749af2d30c220f1b6"
+checksum = "6b43167b4d1812e6902de59bda98c5270855820e1680b6b61389c62a078f495c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.0-pre.3"
+open62541-sys = "0.4.0-pre.4"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This PR makes sure to require the released version 1.4.0 of open62541 to ensure a common baseline for the current pre-release version of this crate.