### PR TITLE
Use multi-threaded runtime in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +464,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "object"
@@ -769,6 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
+ "num_cpus",
  "pin-project-lite",
  "tokio-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3.30"
 env_logger = "0.11.1"
 rand = "0.8.5"
 time = { version = "0.3.31", features = ["macros"] }
-tokio = { version = "1.35.1", features = ["macros"] }
+tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["serde", "time", "tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ futures = "0.3.30"
 env_logger = "0.11.1"
 rand = "0.8.5"
 time = { version = "0.3.31", features = ["macros"] }
+# Enable multi-threaded runtime in examples to increase the chances of finding
+# problems with our use of open62541.
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 
 [features]

--- a/examples/async_browse.rs
+++ b/examples/async_browse.rs
@@ -7,7 +7,7 @@ use anyhow::Context as _;
 use open62541::{ua, AsyncClient, DataType as _, Result};
 use open62541_sys::UA_NS0ID_SERVERTYPE;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context as _};
 use open62541::{ua, AsyncClient, DataType as _, ValueType};
 use open62541_sys::{UA_NS0ID_HASPROPERTY, UA_NS0ID_PROPERTYTYPE};
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -11,7 +11,7 @@ use open62541_sys::{
 };
 use tokio::time;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_client_builder.rs
+++ b/examples/async_client_builder.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use open62541::{ua, ClientBuilder, DataType as _};
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -8,7 +8,7 @@ use open62541_sys::{
 use rand::Rng as _;
 use tokio::time::error::Elapsed;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -18,7 +18,7 @@ const ATTRIBUTE_IDS: [ua::AttributeId; 11] = [
     ua::AttributeId::DATATYPEDEFINITION,
 ];
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -6,7 +6,7 @@ use open62541::{ua, AsyncClient};
 use open62541_sys::UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME;
 use tokio::task;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use crate::{ua, DataType as _, Error, Result};
 /// use open62541::ClientBuilder;
 /// use std::time::Duration;
 ///
-/// # #[tokio::main(flavor = "current_thread")]
+/// # #[tokio::main]
 /// # async fn main() -> anyhow::Result<()> {
 /// #
 /// let client = ClientBuilder::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```no_run
 //! use open62541::AsyncClient;
 //!
-//! # #[tokio::main(flavor = "current_thread")]
+//! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
 //! let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;
@@ -22,7 +22,7 @@
 //! # use open62541::AsyncClient;
 //! use open62541::ua::NodeId;
 //!
-//! # #[tokio::main(flavor = "current_thread")]
+//! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
 //! # let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;
@@ -42,7 +42,7 @@
 //! ```no_run
 //! # use open62541::{AsyncClient, ua::NodeId};
 //! #
-//! # #[tokio::main(flavor = "current_thread")]
+//! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
 //! #
 //! # let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543")?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@ use crate::{ua, DataType, Error, ObjectNode, Result, VariableNode};
 /// use open62541::ServerBuilder;
 /// use std::time::Duration;
 ///
-/// # #[tokio::main(flavor = "current_thread")]
+/// # #[tokio::main]
 /// # async fn main() -> anyhow::Result<()> {
 /// #
 /// let server = ServerBuilder::default()


### PR DESCRIPTION
## Description

This PR adjusts the tokio runtime in the examples to be multi-threaded (the default). This increases the chances of finding problems with our use of open62541.