### PR TITLE
Enable compatibility with Rust 1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ missing_const_for_fn = "warn"
 mod_module_files = "warn"
 pedantic = "warn"
 
+# This warns even when lint group and lint have the same level (`warn`). This is
+# very misleading and results in lots of false positives. See
+# https://github.com/rust-lang/rust-clippy/issues/12270
+lint_groups_priority = "allow"
+
 [[example]]
 name = "async_browse"
 path = "examples/async_browse.rs"

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,9 +1,11 @@
 use crate::{ua, DataType};
 
+#[allow(dead_code)] // --no-default-features
 pub(crate) trait ServiceRequest: DataType + 'static {
     type Response: ServiceResponse;
 }
 
+#[allow(dead_code)] // --no-default-features
 pub(crate) trait ServiceResponse: DataType + 'static {
     type Request: ServiceRequest;
 


### PR DESCRIPTION
## Description

This fixes linting errors introduced with [Rust 1.78](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html).