### PR TITLE
Add array support to ua::Variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add logical OR combinator for `ua::BrowseResultMask` and `ua::NodeClassMask`.
 - Add const `ua::NodeClassMask` variants to initialize masks.
+- Add constructors `ua::Variant::scalar()` and `ua::Variant::array()`.
+- Add `serde` serialization for `ua::Array` and `ua::Variant` with array value.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add logical OR combinator for `ua::BrowseResultMask` and `ua::NodeClassMask`.
 - Add const `ua::NodeClassMask` variants to initialize masks.
-- Add constructors `ua::Variant::scalar()` and `ua::Variant::array()`.
 - Add `serde` serialization for `ua::Array` and `ua::Variant` with array value.
+- Add constructors `ua::Variant::scalar()` and `ua::Variant::array()`.
+- Add constructor `ua::DataValue::new()`.
 
 ### Changed
 
@@ -21,8 +22,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Split `Server::new()` and `ServerBuilder::build()` result type into `Server` and
   `ServerRunner` to allow interacting with server's data tree while server is running.
 - Upgrade to open62541 released version 1.4.0.
-- Deprecate `ua::Variant::with_scalar()`. Instead of `ua::Variant::init().with_scalar(&x)`, use
-  constructor `ua::Variant::scalar(x)`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Split `Server::new()` and `ServerBuilder::build()` result type into `Server` and
   `ServerRunner` to allow interacting with server's data tree while server is running.
 - Upgrade to open62541 released version 1.4.0.
+- Deprecate `ua::Variant::with_scalar()`. Instead of `ua::Variant::init().with_scalar(&x)`, use
+  constructor `ua::Variant::scalar(x)`.
+
+### Fixed
+
+- Avoid memory leak when calling `ua::Variant::with_scalar()` multiple times on the same value.
 
 ## [0.6.0-pre.2] - 2024-04-12
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use open62541::{ua, AsyncClient, DataType as _, ValueType};
+use open62541::{ua, AsyncClient, ValueType};
 use open62541_sys::{UA_NS0ID_HASPROPERTY, UA_NS0ID_PROPERTYTYPE};
 
 #[tokio::main]
@@ -24,7 +24,7 @@ async fn main() -> anyhow::Result<()> {
         &client,
         &object_node_id,
         &method_io_node_id,
-        &[ua::Variant::init().with_scalar(&ua::UInt32::new(123))],
+        &[ua::Variant::scalar(ua::UInt32::new(123))],
     )
     .await?;
 

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -95,8 +95,7 @@ async fn write_background(client: Arc<AsyncClient>, node_id: ua::NodeId) -> anyh
 
     println!("Writing {value} to node {node_id}");
 
-    let value =
-        ua::DataValue::init().with_value(&ua::Variant::init().with_scalar(&ua::Float::new(value)));
+    let value = ua::DataValue::init().with_value(&ua::Variant::scalar(ua::Float::new(value)));
 
     client
         .write_value(&node_id, &value)

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
-use open62541::{ua, AsyncClient, AsyncSubscription, DataType as _};
+use open62541::{ua, AsyncClient, AsyncSubscription};
 use open62541_sys::{
     UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME,
 };
@@ -95,7 +95,7 @@ async fn write_background(client: Arc<AsyncClient>, node_id: ua::NodeId) -> anyh
 
     println!("Writing {value} to node {node_id}");
 
-    let value = ua::DataValue::init().with_value(&ua::Variant::scalar(ua::Float::new(value)));
+    let value = ua::DataValue::new(ua::Variant::scalar(ua::Float::new(value)));
 
     client
         .write_value(&node_id, &value)

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -74,7 +74,7 @@ async fn write_value<T: DataType + Debug>(
     client
         .write_value(
             node_id,
-            &ua::DataValue::init().with_value(&ua::Variant::init().with_scalar(value)),
+            &ua::DataValue::init().with_value(&ua::Variant::scalar(value.clone())),
         )
         .await
         .context("write")?;

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -74,7 +74,7 @@ async fn write_value<T: DataType + Debug>(
     client
         .write_value(
             node_id,
-            &ua::DataValue::init().with_value(&ua::Variant::scalar(value.clone())),
+            &ua::DataValue::new(ua::Variant::scalar(value.clone())),
         )
         .await
         .context("write")?;

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -75,26 +75,6 @@ pub unsafe trait DataType: Debug + Clone {
     #[must_use]
     fn into_raw(self) -> Self::Inner;
 
-    /// Leaks wrapped value onto the heap.
-    ///
-    /// This turns a stack-allocated value into a heap-allocated one, without issuing a deep copy.
-    /// In other words, only the local memory allocation is copied (moved from stack to heap) and
-    /// any memory that is already heap-allocated (e.g. string contents) stays where it is.
-    ///
-    /// The returned value must be passed into another owned data structure or freed manually with
-    /// [`UA_delete()`] to free internal allocations and not leak memory.
-    ///
-    /// [`UA_delete()`]: open62541_sys::UA_delete
-    fn leak_into_raw(self) -> *mut Self::Inner {
-        // This gives up ownership and makes sure that moved data is not freed when scope ends.
-        let src = self.into_raw();
-        // Use `UA_new()` to create heap allocation that can be cleaned up with `UA_free()`.
-        let dst = unsafe { UA_new(Self::data_type()) }.cast::<Self::Inner>();
-        unsafe { ptr::write(dst, src) }
-        // At this point, `src` goes out of scope and is forgotten.
-        dst
-    }
-
     /// Creates wrapper initialized with defaults.
     ///
     /// This uses [`UA_init()`] to initialize the value and make all attributes well-defined.
@@ -198,6 +178,26 @@ pub unsafe trait DataType: Debug + Clone {
         // Move ourselves into the target. This keeps existing memory allocations but we do not
         // reference them anymore because `into_raw()` gives up ownership.
         unsafe { *dst = self.into_raw() };
+    }
+
+    /// Leaks wrapped value onto the heap.
+    ///
+    /// This turns a stack-allocated value into a heap-allocated one, without issuing a deep copy.
+    /// In other words, only the local memory allocation is copied (moved from stack to heap) and
+    /// any memory that is already heap-allocated (e.g. string contents) stays where it is.
+    ///
+    /// The returned value must be passed into another owned data structure or freed manually with
+    /// [`UA_delete()`] to free internal allocations and not leak memory.
+    ///
+    /// [`UA_delete()`]: open62541_sys::UA_delete
+    fn leak_into_raw(self) -> *mut Self::Inner {
+        // Use `UA_new()` to create heap allocation that can be cleaned up with `UA_free()`.
+        let dst = unsafe { UA_new(Self::data_type()) }.cast::<Self::Inner>();
+        // Check that heap allocation was successful (we might be out of memory).
+        assert!(!dst.is_null(), "should have allocated heap memory");
+        // SAFETY: Pointer is valid (non-zero) because we just checked it.
+        self.move_into_raw(unsafe { dst.as_mut().unwrap_unchecked() });
+        dst
     }
 
     /// Creates copy without giving up ownership.

--- a/src/server.rs
+++ b/src/server.rs
@@ -197,8 +197,7 @@ impl Server {
     ///
     /// This fails when the variable node cannot be written.
     pub fn write_variable_string(&self, node_id: &ua::NodeId, value: &str) -> Result<()> {
-        let value = ua::String::new(value)?;
-        let ua_variant = ua::Variant::init().with_scalar(&value);
+        let ua_variant = ua::Variant::scalar(ua::String::new(value)?);
         self.write_variable(node_id, &ua_variant)
     }
 }

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -401,14 +401,13 @@ mod tests {
 
     #[test]
     fn print_array() {
-        let array = ua::Array::from_slice(&[ua::Byte::new(1), ua::Byte::new(2), ua::Byte::new(3)]);
+        let array = ua::Array::from_slice(&[1, 2, 3].map(ua::Byte::new));
         // Our implementation uses the default `Debug` representation of slices.
         assert_eq!("[1, 2, 3]", format!("{array:?}"));
 
-        let array = ua::Array::from_slice(&[
-            ua::String::new("lorem").unwrap(),
-            ua::String::new(r#"ip"sum"#).unwrap(),
-        ]);
+        let array = ua::Array::from_slice(
+            &["lorem", r#"ip"sum"#].map(|string| ua::String::new(string).unwrap()),
+        );
         // String contents are automatically escaped, courtesy of `UA_print()`.
         assert_eq!(r#"["lorem", "ip\"sum"]"#, format!("{array:?}"));
     }

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -4,6 +4,14 @@ crate::data_type!(DataValue);
 
 impl DataValue {
     #[must_use]
+    pub fn new(value: ua::Variant) -> Self {
+        let mut inner = ua::DataValue::init();
+        value.move_into_raw(&mut inner.0.value);
+        inner.0.set_hasValue(true);
+        inner
+    }
+
+    #[must_use]
     pub fn with_value(mut self, value: &ua::Variant) -> Self {
         value.clone_into_raw(&mut self.0.value);
         self.0.set_hasValue(true);

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -41,7 +41,6 @@ impl Variant {
         variant
     }
 
-    #[deprecated(note = "use `Self::scalar()` instead")]
     #[must_use]
     pub fn with_scalar<T: DataType>(mut self, value: &T) -> Self {
         // The call to `UA_Variant_setScalarCopy()` does not free held memory which would lead to a

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -1,8 +1,8 @@
 use std::ffi::c_void;
 
 use open62541_sys::{
-    UA_Variant_hasArrayType, UA_Variant_hasScalarType, UA_Variant_isEmpty, UA_Variant_isScalar,
-    UA_Variant_setScalarCopy,
+    UA_Variant_clear, UA_Variant_hasArrayType, UA_Variant_hasScalarType, UA_Variant_isEmpty,
+    UA_Variant_isScalar, UA_Variant_setArray, UA_Variant_setScalar, UA_Variant_setScalarCopy,
 };
 
 use crate::{ua, DataType, NonScalarValue, ScalarValue, ValueType, VariantValue};
@@ -10,9 +10,45 @@ use crate::{ua, DataType, NonScalarValue, ScalarValue, ValueType, VariantValue};
 crate::data_type!(Variant);
 
 impl Variant {
+    /// Creates variant from scalar.
+    #[must_use]
+    pub fn scalar<T: DataType>(value: T) -> Self {
+        let mut variant = Self::init();
+        // This gives up ownership of the scalar, then moves it into the variant which becomes the
+        // new owner.
+        let ptr = value.leak_into_raw();
+        unsafe {
+            UA_Variant_setScalar(variant.as_mut_ptr(), ptr.cast::<c_void>(), T::data_type());
+        }
+        variant
+    }
+
+    /// Creates variant from array.
+    #[must_use]
+    pub fn array<T: DataType>(value: ua::Array<T>) -> Self {
+        let mut variant = Self::init();
+        // This gives up ownership of the array, then moves it into the variant which becomes the
+        // new owner.
+        let (size, ptr) = value.into_raw_parts();
+        unsafe {
+            UA_Variant_setArray(
+                variant.as_mut_ptr(),
+                ptr.cast::<c_void>(),
+                size,
+                T::data_type(),
+            );
+        }
+        variant
+    }
+
+    #[deprecated(note = "use `Self::scalar()` instead")]
     #[must_use]
     pub fn with_scalar<T: DataType>(mut self, value: &T) -> Self {
+        // The call to `UA_Variant_setScalarCopy()` does not free held memory which would lead to a
+        // memory leak. We must clear the variant manually to handle the case where `with_scalar()`
+        // is called multiple times on the same `Variant`.
         unsafe {
+            UA_Variant_clear(self.as_mut_ptr());
             UA_Variant_setScalarCopy(
                 self.as_mut_ptr(),
                 value.as_ptr().cast::<c_void>(),
@@ -200,7 +236,7 @@ mod tests {
     #[test]
     fn type_boolean() {
         let ua_bool = ua::Boolean::new(true);
-        let ua_variant = ua::Variant::init().with_scalar(&ua_bool);
+        let ua_variant = ua::Variant::scalar(ua_bool);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_BOOLEAN)));
         let value_type = ua_variant.value_type();
@@ -211,7 +247,7 @@ mod tests {
     fn type_int() {
         // Byte
         let ua_byte = ua::Byte::new(42);
-        let ua_variant = ua::Variant::init().with_scalar(&ua_byte);
+        let ua_variant = ua::Variant::scalar(ua_byte);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_BYTE)));
         let value_type = ua_variant.value_type();
@@ -219,7 +255,7 @@ mod tests {
 
         // Int16
         let ua_int16 = ua::Int16::new(-12345);
-        let ua_variant = ua::Variant::init().with_scalar(&ua_int16);
+        let ua_variant = ua::Variant::scalar(ua_int16);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_INT16)));
         let value_type = ua_variant.value_type();
@@ -227,7 +263,7 @@ mod tests {
 
         // UInt32
         let ua_uint32 = ua::UInt32::new(123_456_789);
-        let ua_variant = ua::Variant::init().with_scalar(&ua_uint32);
+        let ua_variant = ua::Variant::scalar(ua_uint32);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_UINT32)));
         let value_type = ua_variant.value_type();
@@ -235,7 +271,7 @@ mod tests {
 
         // Int64
         let ua_int64 = ua::Int64::new(-7_077_926_753_204_279_296);
-        let ua_variant = ua::Variant::init().with_scalar(&ua_int64);
+        let ua_variant = ua::Variant::scalar(ua_int64);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_INT64)));
         let value_type = ua_variant.value_type();
@@ -244,19 +280,19 @@ mod tests {
 
     #[cfg(feature = "serde")]
     mod serde {
-        use crate::{ua, DataType as _};
+        use crate::ua;
 
         #[test]
         fn serialize_bool() {
             // Value `true`
             let ua_bool = ua::Boolean::new(true);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_bool);
+            let ua_variant = ua::Variant::scalar(ua_bool);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("true", json);
 
             // Value `false`
             let ua_bool = ua::Boolean::new(false);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_bool);
+            let ua_variant = ua::Variant::scalar(ua_bool);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("false", json);
         }
@@ -265,25 +301,25 @@ mod tests {
         fn serialize_int() {
             // Byte (unsigned)
             let ua_byte = ua::Byte::new(42);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_byte);
+            let ua_variant = ua::Variant::scalar(ua_byte);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("42", json);
 
             // Int16 (signed)
             let ua_int16 = ua::Int16::new(-12345);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_int16);
+            let ua_variant = ua::Variant::scalar(ua_int16);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("-12345", json);
 
             // UInt32 (unsigned)
             let ua_uint32 = ua::UInt32::new(123_456_789);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_uint32);
+            let ua_variant = ua::Variant::scalar(ua_uint32);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("123456789", json);
 
             // Int64 (signed)
             let ua_int64 = ua::Int64::new(-7_077_926_753_204_279_296);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_int64);
+            let ua_variant = ua::Variant::scalar(ua_int64);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("-7077926753204279296", json);
         }
@@ -292,13 +328,13 @@ mod tests {
         fn serialize_float() {
             // Float
             let ua_float = ua::Float::new(123.4567);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_float);
+            let ua_variant = ua::Variant::scalar(ua_float);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("123.4567", json);
 
             // Double
             let ua_double = ua::Double::new(-98_765_432.1);
-            let ua_variant = ua::Variant::init().with_scalar(&ua_double);
+            let ua_variant = ua::Variant::scalar(ua_double);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("-98765432.1", json);
         }
@@ -307,19 +343,19 @@ mod tests {
         fn serialize_string() {
             // Empty string
             let ua_string = ua::String::new("").unwrap();
-            let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+            let ua_variant = ua::Variant::scalar(ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""""#, json);
 
             // Short string
             let ua_string = ua::String::new("lorem ipsum").unwrap();
-            let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+            let ua_variant = ua::Variant::scalar(ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""lorem ipsum""#, json);
 
             // Special characters
             let ua_string = ua::String::new(r#"a'b"c{dẞe"#).unwrap();
-            let ua_variant = ua::Variant::init().with_scalar(&ua_string);
+            let ua_variant = ua::Variant::scalar(ua_string);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""a'b\"c{dẞe""#, json);
         }
@@ -330,14 +366,14 @@ mod tests {
             // Minute precision
             let datetime = time::macros::datetime!(2024-02-09 16:48 UTC);
             let ua_datetime = ua::DateTime::try_from(datetime).unwrap();
-            let ua_variant = ua::Variant::init().with_scalar(&ua_datetime);
+            let ua_variant = ua::Variant::scalar(ua_datetime);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""2024-02-09T16:48:00Z""#, json);
 
             // Microsecond precision
             let datetime = time::macros::datetime!(2024-02-09 16:48:52.123456 UTC);
             let ua_datetime = ua::DateTime::try_from(datetime).unwrap();
-            let ua_variant = ua::Variant::init().with_scalar(&ua_datetime);
+            let ua_variant = ua::Variant::scalar(ua_datetime);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!(r#""2024-02-09T16:48:52.123456Z""#, json);
         }

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -285,8 +285,7 @@ mod tests {
 
     #[test]
     fn array_ops() {
-        let ua_array =
-            ua::Array::from_slice(&[ua::Byte::new(1), ua::Byte::new(2), ua::Byte::new(3)]);
+        let ua_array = ua::Array::from_slice(&[1, 2, 3].map(ua::Byte::new));
         let ua_variant = ua::Variant::array(ua_array);
         let type_id = ua_variant.type_id();
         assert_eq!(type_id, Some(&ua::NodeId::ns0(UA_NS0ID_BYTE)));
@@ -403,8 +402,7 @@ mod tests {
 
         #[test]
         fn serialize_array() {
-            let ua_array =
-                ua::Array::from_slice(&[ua::Byte::new(1), ua::Byte::new(2), ua::Byte::new(3)]);
+            let ua_array = ua::Array::from_slice(&[1, 2, 3].map(ua::Byte::new));
             let ua_variant = ua::Variant::array(ua_array);
             let json = serde_json::to_string(&ua_variant).unwrap();
             assert_eq!("[1,2,3]", json);


### PR DESCRIPTION
## Description

This adds better support for `ua::Variant` with array values. This also offers an explicit way to create `ua::Variant` from scalar or array values without cloning, and adds serialization support for array values (plain and within variants).