### PR TITLE
Retrieve method definition from empty output argument array fails

### DIFF
--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -44,8 +44,19 @@ async fn main() -> anyhow::Result<()> {
     let event_generator_method_definition =
         get_definition(&client, &event_generator_method_node_id).await?;
     // A method with 2 input arguments and no output arguments (represented by an empty array).
-    assert_eq!(event_generator_method_definition.output_arguments.as_ref().unwrap().len(), 2);
-    assert!(event_generator_method_definition.output_arguments.as_ref().unwrap().is_empty());
+    assert_eq!(
+        event_generator_method_definition
+            .output_arguments
+            .as_ref()
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(event_generator_method_definition
+        .output_arguments
+        .as_ref()
+        .unwrap()
+        .is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
The example fails to decode the output arguments from an empty array.

```
Error: should have array

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
             at /home/uk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.79/src/error.rs:83:36
   1: anyhow::__private::format_err
             at /home/uk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.79/src/lib.rs:684:13
   2: async_call::get_arguments
             at ./examples/async_call.rs:185:16
   3: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
   4: core::option::Option<T>::map
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/option.rs:1073:29
   5: async_call::get_definition::{{closure}}
             at ./examples/async_call.rs:128:28
   6: async_call::main::{{closure}}
             at ./examples/async_call.rs:45:66
   7: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
```