### PR TITLE
Fix decoding of empty method argument arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Coerce _empty_ arrays of `ua::ExtensionObject` into the requested data type. This mirrors the
+  auto-unwrapping behavior of open62541 version 1.4.
+
 ## [0.6.0-pre.3] - 2024-05-18
 
 [0.6.0-pre.3]: https://github.com/HMIProject/open62541/compare/v0.6.0-pre.2...v0.6.0-pre.3

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -8,6 +8,38 @@ async fn main() -> anyhow::Result<()> {
 
     let client = AsyncClient::new("opc.tcp://opcuademo.sterfive.com:26543").context("connect")?;
 
+    let method_node_ids = vec![
+        // The following methods define input/output argument nodes only when at least one argument
+        // exists.
+        //
+        // `/Root/Objects/10:Simulation/10:ObjectWithMethods/10:MethodI`
+        (ua::NodeId::string(10, "MethodI"), 1, 0),
+        // `/Root/Objects/10:Simulation/10:ObjectWithMethods/10:MethodIO`
+        (ua::NodeId::string(10, "MethodIO"), 1, 1),
+        // `/Root/Objects/10:Simulation/10:ObjectWithMethods/10:MethodNoArgs`
+        (ua::NodeId::string(10, "MethodNoArgs"), 0, 0),
+        // `/Root/Objects/10:Simulation/10:ObjectWithMethods/10:MethodO`
+        (ua::NodeId::string(10, "MethodO"), 0, 1),
+        //
+        // The following method is special because it explicitly defines an output argument node of
+        // _empty_ contents.
+        //
+        // `/Root/Objects/10:Simulation/10:EventGeneratorObject/10:EventGeneratorMethod`
+        (ua::NodeId::numeric(10, 1010), 2, 0),
+    ];
+
+    for (node_id, expected_input_args, expected_output_args) in method_node_ids {
+        let (input_arguments, output_arguments) = inspect_method(&client, &node_id).await?;
+        if input_arguments.len() != expected_input_args {
+            anyhow::bail!("unexpected number of input arguments");
+        }
+        if output_arguments.len() != expected_output_args {
+            anyhow::bail!("unexpected number of output arguments");
+        }
+    }
+
+    println!();
+
     // `/Root/Objects/10:Simulation/10:ObjectWithMethods`
     let object_node_id = ua::NodeId::string(10, "ObjectWithMethods");
     // `/Root/Objects/10:Simulation/10:ObjectWithMethods/10:MethodNoArgs`
@@ -37,28 +69,24 @@ async fn main() -> anyhow::Result<()> {
 
     println!("-> {value}");
 
-    // `/Root/Objects/10:Simulation/10:EventGeneratorObject`
-    let _event_generator_object_node_id = ua::NodeId::numeric(10, 1009);
-    // `/Root/Objects/10:Simulation/10:EventGeneratorObject/10:EventGeneratorMethod`
-    let event_generator_method_node_id = ua::NodeId::numeric(10, 1010);
-    let event_generator_method_definition =
-        get_definition(&client, &event_generator_method_node_id).await?;
-    // A method with 2 input arguments and no output arguments (represented by an empty array).
-    assert_eq!(
-        event_generator_method_definition
-            .output_arguments
-            .as_ref()
-            .unwrap()
-            .len(),
-        2
-    );
-    assert!(event_generator_method_definition
-        .output_arguments
-        .as_ref()
-        .unwrap()
-        .is_empty());
-
     Ok(())
+}
+
+async fn inspect_method(
+    client: &AsyncClient,
+    method_node_id: &ua::NodeId,
+) -> anyhow::Result<(Vec<(ua::String, ValueType)>, Vec<(ua::String, ValueType)>)> {
+    println!("Getting method definition of node {method_node_id}");
+
+    let definition = get_definition(client, method_node_id).await?;
+
+    let input_arguments = definition.input_arguments.unwrap_or_default();
+    let output_arguments = definition.output_arguments.unwrap_or_default();
+
+    println!("- input arguments: {input_arguments:?}");
+    println!("- output arguments: {output_arguments:?}");
+
+    Ok((input_arguments, output_arguments))
 }
 
 async fn call_method(
@@ -67,19 +95,6 @@ async fn call_method(
     method_node_id: &ua::NodeId,
     input_arguments: &[ua::Variant],
 ) -> anyhow::Result<Vec<ua::Variant>> {
-    println!("Getting method definition of node {method_node_id}");
-
-    let definition = get_definition(client, method_node_id).await?;
-
-    println!(
-        "- input arguments: {:?}",
-        definition.input_arguments.unwrap_or_default()
-    );
-    println!(
-        "- output arguments: {:?}",
-        definition.output_arguments.unwrap_or_default()
-    );
-
     println!("Calling node {method_node_id}");
 
     let output_arguments = client
@@ -187,13 +202,20 @@ async fn read_sparse_node_values(
 /// and returns the list of argument names and their value types.
 fn get_arguments(value: &ua::DataValue) -> anyhow::Result<Vec<(ua::String, ValueType)>> {
     // `InputArguments` and `OutputArguments` nodes are expected to hold an array of objects of the
-    // `Argument` type.
+    // `Argument` type. Only when no arguments are available, the value may also be of the original
+    // `Structure` type (encoded as `ua::ExtensionObject`).
 
-    let arguments = value
-        .value()
-        .ok_or(anyhow::anyhow!("should have value"))?
-        .to_array::<ua::Argument>()
-        .ok_or(anyhow::anyhow!("should have array"))?;
+    let value = value.value().ok_or(anyhow::anyhow!("should have value"))?;
+
+    let arguments = match value.to_array::<ua::Argument>() {
+        Some(arguments) => arguments,
+
+        // Fall back to `Structure` array but allow only when it is empty.
+        None => match value.to_array::<ua::ExtensionObject>() {
+            Some(arguments) if arguments.is_empty() => ua::Array::new(0),
+            _ => anyhow::bail!("should have array"),
+        },
+    };
 
     Ok(arguments
         .iter()

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -202,20 +202,13 @@ async fn read_sparse_node_values(
 /// and returns the list of argument names and their value types.
 fn get_arguments(value: &ua::DataValue) -> anyhow::Result<Vec<(ua::String, ValueType)>> {
     // `InputArguments` and `OutputArguments` nodes are expected to hold an array of objects of the
-    // `Argument` type. Only when no arguments are available, the value may also be of the original
-    // `Structure` type (encoded as `ua::ExtensionObject`).
+    // `Argument` type.
 
-    let value = value.value().ok_or(anyhow::anyhow!("should have value"))?;
-
-    let arguments = match value.to_array::<ua::Argument>() {
-        Some(arguments) => arguments,
-
-        // Fall back to `Structure` array but allow only when it is empty.
-        None => match value.to_array::<ua::ExtensionObject>() {
-            Some(arguments) if arguments.is_empty() => ua::Array::new(0),
-            _ => anyhow::bail!("should have array"),
-        },
-    };
+    let arguments = value
+        .value()
+        .ok_or(anyhow::anyhow!("should have value"))?
+        .to_array::<ua::Argument>()
+        .ok_or(anyhow::anyhow!("should have array"))?;
 
     Ok(arguments
         .iter()

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -37,6 +37,16 @@ async fn main() -> anyhow::Result<()> {
 
     println!("-> {value}");
 
+    // `/Root/Objects/10:Simulation/10:EventGeneratorObject`
+    let _event_generator_object_node_id = ua::NodeId::numeric(10, 1009);
+    // `/Root/Objects/10:Simulation/10:EventGeneratorObject/10:EventGeneratorMethod`
+    let event_generator_method_node_id = ua::NodeId::numeric(10, 1010);
+    let event_generator_method_definition =
+        get_definition(&client, &event_generator_method_node_id).await?;
+    // A method with 2 input arguments and no output arguments (represented by an empty array).
+    assert_eq!(event_generator_method_definition.output_arguments.as_ref().unwrap().len(), 2);
+    assert!(event_generator_method_definition.output_arguments.as_ref().unwrap().is_empty());
+
     Ok(())
 }
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -44,8 +44,19 @@ async fn main() -> anyhow::Result<()> {
     let event_generator_method_definition =
         get_definition(&client, &event_generator_method_node_id).await?;
     // A method with 2 input arguments and no output arguments (represented by an empty array).
-    assert_eq!(event_generator_method_definition.output_arguments.as_ref().unwrap().len(), 2);
-    assert!(event_generator_method_definition.output_arguments.as_ref().unwrap().is_empty());
+    assert_eq!(
+        event_generator_method_definition
+            .output_arguments
+            .as_ref()
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(event_generator_method_definition
+        .output_arguments
+        .as_ref()
+        .unwrap()
+        .is_empty());
 
     Ok(())
 }

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -109,11 +109,15 @@ impl Variant {
             //
             // To make handling such arrays easier in user code, we allow _coercion_ of such empty
             // arrays into any data type.
-            let is_empty_array = self.0.arrayLength == 0
+            let is_empty_structured_array = self.0.arrayLength == 0
                 && unsafe {
                     UA_Variant_hasArrayType(self.as_ptr(), ua::ExtensionObject::data_type())
                 };
-            return is_empty_array.then_some(ua::Array::new(0));
+            if !is_empty_structured_array {
+                return None;
+            }
+            // Fall through to let `ua::Array::from_raw_parts()` handle the distinction between an
+            // empty and an invalid array (where `self.0.data` is the sentinel value or null).
         }
         ua::Array::from_raw_parts(self.0.data.cast::<T::Inner>(), self.0.arrayLength)
     }


### PR DESCRIPTION
## Description

This fixes a regression with empty argument arrays where decoding fails due to an unexpected type `Structure` (i.e. raw extension object) instead of `Argument` reported from the open62541 library, despite the auto-unwrapping introduced in open62541 version 1.4. This happens because for empty arrays the array element type cannot be known.

To handle such cases in user code more easily, we add a coercion of empty structured arrays into any given data type.