### PR TITLE
Upgrade open62541 and remove workaround mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to open62541 released version 1.4.1. This removes the workaround introduced in
+  0.6.0-pre.3, it is no longer necessary.
+
 ## [0.6.0-pre.4] - 2024-05-22
 
 [0.6.0-pre.4]: https://github.com/HMIProject/open62541/compare/v0.6.0-pre.3...v0.6.0-pre.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.0-pre.4"
+version = "0.4.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b43167b4d1812e6902de59bda98c5270855820e1680b6b61389c62a078f495c"
+checksum = "1c8a317d6e217e461f99f03ab692ea0ca003a66bac6f9be5bd4ee3d581eed986"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.0-pre.4"
+open62541-sys = "0.4.0-pre.5"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -3,7 +3,7 @@ use std::{
     ptr, slice,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc,
     },
     thread::{self, JoinHandle},
     time::Duration,
@@ -28,7 +28,7 @@ use crate::{
 /// Since this is also the timeout we must block for when dropping the client without `disconnect()`
 /// first, the value should not be too large. On the other hand, it should not be too small to avoid
 /// repeatedly calling `poll()`/`select()` inside open62541's event loop implementation.
-const RUN_ITERATE_TIMEOUT: Duration = Duration::from_millis(1);
+const RUN_ITERATE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Connected OPC UA client (with asynchronous API).
 ///
@@ -39,10 +39,7 @@ const RUN_ITERATE_TIMEOUT: Duration = Duration::from_millis(1);
 ///
 /// See [Client](crate::Client) for more details.
 pub struct AsyncClient {
-    // The mutex here is a temporary workaround and should be removed again soon (along with all the
-    // other changes from the same commit). See https://github.com/HMIProject/open62541/pull/107 for
-    // more details and an explanation.
-    client: Arc<Mutex<ua::Client>>,
+    client: Arc<ua::Client>,
     background_canceled: Arc<AtomicBool>,
     background_handle: Option<JoinHandle<()>>,
 }
@@ -69,7 +66,7 @@ impl AsyncClient {
     }
 
     pub(crate) fn from_sync(client: ua::Client) -> Self {
-        let client = Arc::new(Mutex::new(client));
+        let client = Arc::new(client);
 
         let background_canceled = Arc::new(AtomicBool::new(false));
 
@@ -120,13 +117,9 @@ impl AsyncClient {
     }
 
     /// Gets current channel and session state, and connect status.
-    #[allow(clippy::missing_panics_doc)] // Allow until mutex handling is gone again.
     #[must_use]
     pub fn state(&self) -> ua::ClientState {
-        let Ok(client) = self.client.lock() else {
-            panic!("mutex should not have been poisoned");
-        };
-        client.state()
+        self.client.state()
     }
 
     /// Disconnects from endpoint.
@@ -134,15 +127,14 @@ impl AsyncClient {
     /// This consumes the client and handles the graceful shutdown of the connection. This should be
     /// preferred over simply dropping the instance to give the server a chance to clean up and also
     /// to avoid blocking unexpectedly when the client is being dropped without calling this method.
-    #[allow(clippy::missing_panics_doc)] // Allow until mutex handling is gone again.
     pub async fn disconnect(mut self) {
         log::info!("Disconnecting from endpoint");
 
-        let status_code = ua::StatusCode::new({
-            let Ok(mut client) = self.client.lock() else {
-                panic!("mutex should not have been poisoned");
-            };
-            unsafe { UA_Client_disconnectAsync(client.as_mut_ptr()) }
+        let status_code = ua::StatusCode::new(unsafe {
+            UA_Client_disconnectAsync(
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                self.client.as_ptr().cast_mut(),
+            )
         });
         if let Err(error) = Error::verify_good(&status_code) {
             log::warn!("Error while disconnecting client: {error}");
@@ -479,7 +471,7 @@ impl Drop for AsyncClient {
 /// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
 /// and for final connection failures), the cancellation token `cancel` can be used to stop the task
 /// from the outside before the next loop iteration.
-fn background_task(client: &Arc<Mutex<ua::Client>>, canceled: &AtomicBool) {
+fn background_task(client: &ua::Client, canceled: &AtomicBool) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.
@@ -494,13 +486,16 @@ fn background_task(client: &Arc<Mutex<ua::Client>>, canceled: &AtomicBool) {
         let status_code = ua::StatusCode::new({
             log::trace!("Running iterate");
 
-            let Ok(mut client) = client.lock() else {
-                panic!("mutex should not have been poisoned");
-            };
             // This returns after the timeout even when nothing was processed. The internal mutex is
             // _not_ held for the entire time though, so we can send out requests concurrently while
             // the client is running the iteration.
-            unsafe { UA_Client_run_iterate(client.as_mut_ptr(), timeout_millis) }
+            unsafe {
+                UA_Client_run_iterate(
+                    // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                    client.as_ptr().cast_mut(),
+                    timeout_millis,
+                )
+            }
         });
         if let Err(error) = Error::verify_good(&status_code) {
             // Context-sensitive handling of bad status codes.
@@ -529,7 +524,7 @@ fn background_task(client: &Arc<Mutex<ua::Client>>, canceled: &AtomicBool) {
 }
 
 async fn service_request<R: ServiceRequest>(
-    client: &Arc<Mutex<ua::Client>>,
+    client: &ua::Client,
     request: R,
 ) -> Result<R::Response> {
     type Cb<R> = CallbackOnce<std::result::Result<<R as ServiceRequest>::Response, ua::StatusCode>>;
@@ -576,21 +571,17 @@ async fn service_request<R: ServiceRequest>(
     log::debug!("Running {}", R::type_name());
 
     let mut request_id: UA_UInt32 = 0;
-    let status_code = ua::StatusCode::new({
-        let Ok(mut client) = client.lock() else {
-            panic!("mutex should not have been poisoned");
-        };
-        unsafe {
-            __UA_Client_AsyncService(
-                client.as_mut_ptr(),
-                request.as_ptr().cast::<c_void>(),
-                R::data_type(),
-                Some(callback_c::<R>),
-                R::Response::data_type(),
-                Cb::<R>::prepare(callback),
-                ptr::addr_of_mut!(request_id),
-            )
-        }
+    let status_code = ua::StatusCode::new(unsafe {
+        __UA_Client_AsyncService(
+            // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+            client.as_ptr().cast_mut(),
+            request.as_ptr().cast::<c_void>(),
+            R::data_type(),
+            Some(callback_c::<R>),
+            R::Response::data_type(),
+            Cb::<R>::prepare(callback),
+            ptr::addr_of_mut!(request_id),
+        )
     });
     // The request itself fails when the client is not connected (or the secure session has not been
     // established). In all other cases, `open62541` processes the request first and then may reject

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::c_void,
     ptr,
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Weak},
 };
 
 use futures_channel::oneshot;
@@ -14,12 +14,12 @@ use crate::{ua, AsyncMonitoredItem, CallbackOnce, DataType as _, Error, Result};
 
 /// Subscription (with asynchronous API).
 pub struct AsyncSubscription {
-    client: Weak<Mutex<ua::Client>>,
+    client: Weak<ua::Client>,
     subscription_id: ua::SubscriptionId,
 }
 
 impl AsyncSubscription {
-    pub(crate) async fn new(client: &Arc<Mutex<ua::Client>>) -> Result<Self> {
+    pub(crate) async fn new(client: &Arc<ua::Client>) -> Result<Self> {
         let request = ua::CreateSubscriptionRequest::default();
 
         let response = create_subscription(client, &request).await?;
@@ -60,7 +60,7 @@ impl Drop for AsyncSubscription {
 }
 
 async fn create_subscription(
-    client: &Arc<Mutex<ua::Client>>,
+    client: &ua::Client,
     request: &ua::CreateSubscriptionRequest,
 ) -> Result<ua::CreateSubscriptionResponse> {
     type Cb = CallbackOnce<std::result::Result<ua::CreateSubscriptionResponse, ua::StatusCode>>;
@@ -107,12 +107,10 @@ async fn create_subscription(
         // does not take ownership.
         let request = unsafe { ua::CreateSubscriptionRequest::to_raw_copy(request) };
 
-        let Ok(mut client) = client.lock() else {
-            panic!("mutex should not have been poisoned");
-        };
         unsafe {
             UA_Client_Subscriptions_create_async(
-                client.as_mut_ptr(),
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                client.as_ptr().cast_mut(),
                 request,
                 ptr::null_mut(),
                 None,
@@ -132,7 +130,7 @@ async fn create_subscription(
         .unwrap_or(Err(Error::internal("callback should send result")))
 }
 
-fn delete_subscriptions(client: &Arc<Mutex<ua::Client>>, request: &ua::DeleteSubscriptionsRequest) {
+fn delete_subscriptions(client: &ua::Client, request: &ua::DeleteSubscriptionsRequest) {
     unsafe extern "C" fn callback_c(
         _client: *mut UA_Client,
         _userdata: *mut c_void,
@@ -159,12 +157,10 @@ fn delete_subscriptions(client: &Arc<Mutex<ua::Client>>, request: &ua::DeleteSub
         // does not take ownership.
         let request = unsafe { ua::DeleteSubscriptionsRequest::to_raw_copy(request) };
 
-        let Ok(mut client) = client.lock() else {
-            panic!("mutex should not have been poisoned");
-        };
         unsafe {
             UA_Client_Subscriptions_delete_async(
-                client.as_mut_ptr(),
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                client.as_ptr().cast_mut(),
                 request,
                 Some(callback_c),
                 ptr::null_mut(),


### PR DESCRIPTION
## Description

This upgrades to the latest open62541 release which fixes the error described in #107. The workaround we did there, by adding back the client mutex, is no longer necessary and has been reverted.