### PR TITLE
AsyncMonitoredItem: Propagate trait bounds of futures::stream::Unfold

### DIFF
--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -64,7 +64,7 @@ impl AsyncMonitoredItem {
     ///
     /// The stream will emit all value updates as they are being received. If the client disconnects
     /// or the corresponding subscription is deleted, the stream is closed.
-    pub fn into_stream(self) -> impl Stream<Item = ua::DataValue> {
+    pub fn into_stream(self) -> impl Stream<Item = ua::DataValue> + Send + Sync + Unpin + 'static {
         stream::unfold(self, move |mut this| async move {
             this.next().await.map(|value| (value, this))
         })


### PR DESCRIPTION
...to avoid boxing in downstream code.