### PR TITLE
Add more variants to `StatusCode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Add `BADINTERNALERROR` and `BADWRITENOTSUPPORTED` variants to `ua::StatusCode`.
+
 ### Changed
 
 - Include appropriate trait bounds in return type of `AsyncMonitoredItem::into_stream()`.

--- a/src/ua/data_types/status_code.rs
+++ b/src/ua/data_types/status_code.rs
@@ -2,7 +2,8 @@ use std::{ffi::CStr, fmt};
 
 use open62541_sys::{
     UA_StatusCode, UA_StatusCode_isBad, UA_StatusCode_isGood, UA_StatusCode_isUncertain,
-    UA_StatusCode_name, UA_STATUSCODE_GOOD,
+    UA_StatusCode_name, UA_STATUSCODE_BADINTERNALERROR, UA_STATUSCODE_BADWRITENOTSUPPORTED,
+    UA_STATUSCODE_GOOD,
 };
 
 crate::data_type!(StatusCode);
@@ -10,6 +11,12 @@ crate::data_type!(StatusCode);
 impl StatusCode {
     /// Enum variant [`UA_STATUSCODE_GOOD`] from [`open62541_sys`].
     pub const GOOD: Self = Self(UA_STATUSCODE_GOOD);
+
+    /// Enum variant [`UA_STATUSCODE_BADINTERNALERROR`] from [`open62541_sys`].
+    pub const BADINTERNALERROR: Self = Self(UA_STATUSCODE_BADINTERNALERROR);
+
+    /// Enum variant [`UA_STATUSCODE_BADWRITENOTSUPPORTED`] from [`open62541_sys`].
+    pub const BADWRITENOTSUPPORTED: Self = Self(UA_STATUSCODE_BADWRITENOTSUPPORTED);
 
     /// Creates wrapper by taking ownership of `src`.
     #[must_use]


### PR DESCRIPTION
## Description

This adds two more variants `BADINTERNALERROR` and `BADWRITENOTSUPPORTED` to `ua::StatusCode`. These will be required in upcoming features.