### PR TITLE
Add documentation to some methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,10 @@ pub enum Error {
 }
 
 impl Error {
+    /// Creates error from status code.
+    ///
+    /// To avoid confusion, the status code should be considered bad or uncertain but not good, as
+    /// indicated by [`ua::StatusCode::is_good()`].
     #[must_use]
     pub(crate) fn new(status_code: ua::StatusCode) -> Self {
         debug_assert!(!status_code.is_good());

--- a/src/ua/continuation_point.rs
+++ b/src/ua/continuation_point.rs
@@ -5,6 +5,12 @@ use crate::ua;
 pub struct ContinuationPoint(ua::ByteString);
 
 impl ContinuationPoint {
+    /// Creates continuation point from raw string.
+    ///
+    /// This may return [`None`] when the string is invalid (as defined by OPC UA). This is used in
+    /// [`ua::BrowseResult`] to indicate that no continuation point was necessary.
+    ///
+    /// Note: The given string should not be empty.
     #[must_use]
     pub(crate) fn new(continuation_point: &ua::ByteString) -> Option<Self> {
         // Unset continuation points indicate that the `BrowseResult` contains all references and no
@@ -13,7 +19,8 @@ impl ContinuationPoint {
             return None;
         }
 
-        // The continuation point should not be an empty string.
+        // An empty string would be a strange continuation point. Nothing bad would happen since
+        // this is not an invalid string (as defined by OPC UA) but it might indicate an error.
         debug_assert!(!continuation_point.is_empty());
 
         Some(Self(continuation_point.clone()))

--- a/src/ua/data_types/status_code.rs
+++ b/src/ua/data_types/status_code.rs
@@ -32,14 +32,14 @@ impl StatusCode {
     /// Note: This only checks the _severity_ of the status code. If you want to see if the code is
     /// exactly the single status code [`GOOD`](Self::GOOD), use comparison instead:
     ///
-    /// ```rust
+    /// ```
     /// use open62541::ua;
     ///
     /// # let status_code = ua::StatusCode::GOOD;
     /// if status_code == ua::StatusCode::GOOD {
     ///     //
     /// }
-    /// ````
+    /// ```
     #[must_use]
     pub fn is_good(&self) -> bool {
         unsafe { UA_StatusCode_isGood(self.0) }


### PR DESCRIPTION
## Description

This adds missing documentation to some (internal) methods. In the code, we use `debug_assert!()` in situations where we expect something that we control ourselves but nothing too bad would happen if that were not the case.[^1]

[^1]: This is different from `assert!()` where the situation may happen spuriously at runtime and we need to include explicit `# Panics` sections in the documentation.