### PR TITLE
Allow defining variable nodes with (callback-driven) `DataSource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Allow defining callback-driven variable nodes with `Server::add_data_source_variable_node()`.
 - Allow deletion of server nodes with `Server::delete_node()`.
 - Add `BADINTERNALERROR` and `BADWRITENOTSUPPORTED` variants to `ua::StatusCode`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
     error::{Error, Result},
-    server::{Server, ServerBuilder, ServerRunner},
+    server::{DataSource, Server, ServerBuilder, ServerRunner},
     server_nodes::{ObjectNode, VariableNode},
     userdata::Userdata,
     value::{ScalarValue, ValueType, VariantValue},

--- a/src/server/data_source.rs
+++ b/src/server/data_source.rs
@@ -1,0 +1,142 @@
+use std::ffi::c_void;
+
+use open62541_sys::{
+    UA_Boolean, UA_DataSource, UA_DataValue, UA_NodeId, UA_NumericRange, UA_Server, UA_StatusCode,
+};
+
+use crate::{server::NodeContext, ua, DataType};
+
+/// Read callback for [`DataSource`].
+#[allow(clippy::module_name_repetitions)]
+pub type DataSourceRead = dyn FnMut(&mut DataSourceReadContext) -> DataSourceResult;
+
+/// Write callback for [`DataSource`].
+#[allow(clippy::module_name_repetitions)]
+pub type DataSourceWrite = dyn FnMut(&mut DataSourceWriteContext) -> DataSourceResult;
+
+/// Data source with callbacks.
+///
+/// The read and write callbacks implement the operations on the data source when it is added as a
+/// variable node via [`Server::add_data_source_variable_node()`].
+///
+/// [`Server::add_data_source_variable_node()`]: crate::Server::add_data_source_variable_node
+pub struct DataSource {
+    read: Box<DataSourceRead>,
+    write: Option<Box<DataSourceWrite>>,
+}
+
+impl DataSource {
+    /// Defines read-only data source.
+    #[must_use]
+    pub fn read_only(
+        read: impl FnMut(&mut DataSourceReadContext) -> DataSourceResult + 'static,
+    ) -> Self {
+        Self {
+            read: Box::new(read),
+            write: None,
+        }
+    }
+
+    /// Defines writable data source.
+    #[must_use]
+    pub fn read_write(
+        read: impl FnMut(&mut DataSourceReadContext) -> DataSourceResult + 'static,
+        write: impl FnMut(&mut DataSourceWriteContext) -> DataSourceResult + 'static,
+    ) -> Self {
+        Self {
+            read: Box::new(read),
+            write: Some(Box::new(write)),
+        }
+    }
+
+    /// Transforms into raw value.
+    ///
+    /// # Safety
+    ///
+    /// The returned [`UA_DataSource`] is only valid for as long as [`NodeContext`] is alive. The
+    /// lifetime can be extended by using [`NodeContext::leak()`] to save this value inside the
+    /// corresponding server node, to be eventually cleaned up when the node is destroyed.
+    pub(crate) unsafe fn into_raw(self) -> (UA_DataSource, NodeContext) {
+        unsafe extern "C" fn read_c(
+            _server: *mut UA_Server,
+            _session_id: *const UA_NodeId,
+            _session_context: *mut c_void,
+            _node_id: *const UA_NodeId,
+            node_context: *mut c_void,
+            _include_source_time_stamp: UA_Boolean,
+            _range: *const UA_NumericRange,
+            _value: *mut UA_DataValue,
+        ) -> UA_StatusCode {
+            let node_context = unsafe { NodeContext::peek_at(node_context) };
+            #[allow(irrefutable_let_patterns)] // We will add more node context types eventually.
+            let NodeContext::DataSource(data_source) = node_context
+            else {
+                // We expect to always find this node context type.
+                return ua::StatusCode::BADINTERNALERROR.into_raw();
+            };
+            let DataSource { read, .. } = data_source;
+
+            // TODO: Prepare callback context.
+            let mut context = DataSourceReadContext;
+
+            match read(&mut context) {
+                Ok(()) => ua::StatusCode::GOOD,
+                Err(status_code) => status_code,
+            }
+            .into_raw()
+        }
+
+        unsafe extern "C" fn write_c(
+            _server: *mut UA_Server,
+            _session_id: *const UA_NodeId,
+            _session_context: *mut c_void,
+            _node_id: *const UA_NodeId,
+            node_context: *mut c_void,
+            _range: *const UA_NumericRange,
+            _value: *const UA_DataValue,
+        ) -> UA_StatusCode {
+            let node_context = unsafe { NodeContext::peek_at(node_context) };
+            #[allow(irrefutable_let_patterns)] // We will add more node context types eventually.
+            let NodeContext::DataSource(data_source) = node_context
+            else {
+                // We expect to always find this node context type.
+                return ua::StatusCode::BADINTERNALERROR.into_raw();
+            };
+            let DataSource { write, .. } = data_source;
+            let Some(write) = write else {
+                return ua::StatusCode::BADWRITENOTSUPPORTED.into_raw();
+            };
+
+            // TODO: Prepare callback context.
+            let mut context = DataSourceWriteContext;
+
+            match write(&mut context) {
+                Ok(()) => ua::StatusCode::GOOD,
+                Err(status_code) => status_code,
+            }
+            .into_raw()
+        }
+
+        let data_source = UA_DataSource {
+            // The read callback is expected.
+            read: Some(read_c),
+            // The write callback is optional.
+            write: self.write.is_some().then_some(write_c),
+        };
+
+        let node_context = NodeContext::DataSource(self);
+
+        (data_source, node_context)
+    }
+}
+
+// TODO: Add ability to transmit read value back to server.
+#[allow(clippy::module_name_repetitions)]
+pub struct DataSourceReadContext;
+
+// TODO: Add ability to receive written value from server.
+#[allow(clippy::module_name_repetitions)]
+pub struct DataSourceWriteContext;
+
+#[allow(clippy::module_name_repetitions)]
+pub type DataSourceResult = std::result::Result<(), ua::StatusCode>;

--- a/src/server/node_context.rs
+++ b/src/server/node_context.rs
@@ -1,13 +1,13 @@
 use std::ffi::c_void;
 
-use crate::Userdata;
+use crate::{server::DataSource, Userdata};
 
 /// Context attached to server node.
 ///
 /// Nodes created by [`Server`](crate::Server) need to keep track of dynamic data structures. These
 /// are cleaned up when the corresponding node is destroyed by the server.
 pub(crate) enum NodeContext {
-    // We will add specific payloads here.
+    DataSource(DataSource),
 }
 
 #[allow(dead_code)] // We will use the methods soon.


### PR DESCRIPTION
## Description

This PR introduces callback-driven variable nodes with the use of `DataSource`. (This is not yet feature-complete, and more work will be done in upcoming PRs.)

The general idea of data source variable nodes is to allow users to handle storage manually, in contrast to the existing plain `Server::add_variable_node()` which handles storage inside.