### PR TITLE
Add missing prefix in `BrowseNextRequest` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Include appropriate trait bounds in return type of `AsyncMonitoredItem::into_stream()`.
+- Breaking: Add prefix `with_` in `ua::BrowseNextRequest::with_release_continuation_points()`.
 
 ## [0.6.0-pre.5] - 2024-05-31
 

--- a/src/ua/data_types/browse_next_request.rs
+++ b/src/ua/data_types/browse_next_request.rs
@@ -21,7 +21,7 @@ impl BrowseNextRequest {
     }
 
     #[must_use]
-    pub fn release_continuation_points(mut self, release_continuation_points: bool) -> Self {
+    pub fn with_release_continuation_points(mut self, release_continuation_points: bool) -> Self {
         self.0.releaseContinuationPoints = release_continuation_points;
         self
     }


### PR DESCRIPTION
## Description

This adds the missing prefix `with_` in builder method to match the expected pattern used in other methods.