### PR TITLE
Upgrade to open62541 version 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Include appropriate trait bounds in return type of `AsyncMonitoredItem::into_stream()`.
 - Breaking: Add prefix `with_` in `ua::BrowseNextRequest::with_release_continuation_points()`.
+- Upgrade to open62541 released version 1.4.2.
 
 ## [0.6.0-pre.5] - 2024-05-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.0-pre.5"
+version = "0.4.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8a317d6e217e461f99f03ab692ea0ca003a66bac6f9be5bd4ee3d581eed986"
+checksum = "70429d9ad8e71defe988e9362a81830d0634a888cd5dc8bc574815ba1f8dd8cf"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.0-pre.5"
+open62541-sys = "0.4.0-pre.6"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest release of [open62541](https://github.com/open62541/open62541).