### PR TITLE
Upgrade to stable `open62541-sys` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.0-pre.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70429d9ad8e71defe988e9362a81830d0634a888cd5dc8bc574815ba1f8dd8cf"
+checksum = "2124b3ade1f11c3594e8202d7d677728a8a48ba98307c0a828e35d8b97bba2db"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.0-pre.6"
+open62541-sys = "0.4.0"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This PR updates the dependency on [open62541-sys](https://github.com/HMIProject/open62541-sys) to the recently released stable version.