### PR TITLE
Change visibility of `NodeContext` to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add known enum variants to `ua::StatusCode`.
 - Add method `ua::ExpandedNodeId::numeric()` to create numeric expanded node IDs.
 - Add type `ua::RelativePathElement`.
+- Change visibility of `NodeContext` to be public.
 
 ### Changed
 

--- a/src/server/node_context.rs
+++ b/src/server/node_context.rs
@@ -6,7 +6,7 @@ use crate::{server::DataSource, Userdata};
 ///
 /// Nodes created by [`Server`](crate::Server) need to keep track of dynamic data structures. These
 /// are cleaned up when the corresponding node is destroyed by the server.
-pub(crate) enum NodeContext {
+pub enum NodeContext {
     DataSource(Box<dyn DataSource>),
 }
 


### PR DESCRIPTION
This is required in #133 and other features currently in #126 