### PR TITLE
Avoid destruction of unknown node context for now

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -87,6 +87,8 @@ impl ServerBuilder {
             //
             // Note: The above assumption is not correct. See issue for more details:
             // <https://github.com/HMIProject/open62541/issues/125>
+            //
+            // FIXME: Find solution to prevent memory leak.
             if !node_context.is_null() {
                 if let Some(node_id) = unsafe { node_id.as_ref() }.map(ua::NodeId::raw_ref) {
                     log::debug!("Destroying node {node_id}, freeing associated data");


### PR DESCRIPTION
## Description

This PR is a workaround for #125 to prevent segfaults. See that issue for more details and further investigations to properly solve the underlying problem.

The changes leak memory: associated data for created nodes is not freed. As long as the server's node tree is static, this is not a problem. But we must be aware that repeated node creation and destruction during the server's runtime will fill up the available heap memory.