### PR TITLE
Add `Lifecycle` and `LifecycleManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Implement `Index` and `IndexMut` for `ua::Array` to allow direct element access.
 - Add methods `Server::write_object_property()` and `Server::read_object_property()`.
 - Add methods `Server::create_event()` and `Server::trigger_event()`.
+- Add `Lifecycle` and `LifecyclManager`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@ pub use self::{
     error::{Error, Result},
     server::{
         DataSource, DataSourceError, DataSourceReadContext, DataSourceResult,
-        DataSourceWriteContext, Node, ObjectNode, Server, ServerBuilder, ServerRunner,
-        VariableNode,
+        DataSourceWriteContext, Lifecycle, LifecycleManager, Node, ObjectNode, Server,
+        ServerBuilder, ServerRunner, VariableNode,
     },
     traits::Attributes,
     userdata::Userdata,
@@ -98,6 +98,7 @@ pub use self::{
 pub(crate) use self::{
     data_type::{bitmask_ops, data_type, enum_variants},
     logger::logger,
+    server::NodeContext,
     service::{ServiceRequest, ServiceResponse},
     value::{ArrayValue, NonScalarValue},
 };

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -20,7 +20,6 @@ pub trait Lifecycle {
     #[allow(unused_variables)]
     fn constructor(
         &self,
-        server: &mut Server,
         session_id: &NodeId,
         session_context: *mut c_void,
         type_id: &NodeId,
@@ -40,7 +39,6 @@ pub trait Lifecycle {
     #[allow(unused_variables)]
     fn destructor(
         &self,
-        server: &mut Server,
         session_id: &NodeId,
         session_context: *mut c_void,
         type_id: &NodeId,

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -1,0 +1,51 @@
+use std::ffi::c_void;
+
+use crate::ua;
+use crate::ua::NodeId;
+use crate::Server;
+
+/// Holds constructor and destructor for a `Node` type
+///
+/// Implement this trait on a struct to be able to use the
+/// `LifecycleManager`.
+pub trait Lifecycle {
+    /// Constructor for a node where this `Lifecycle` was added to.
+    ///
+    /// Only returns `ua::StatusCode::GOOD` and does
+    /// nothing else by default.
+    ///
+    /// Has a shared reference to self, so there is no need to worry
+    /// about thread-safety, if a struct implementing this trait
+    /// has fields.
+    #[allow(unused_variables)]
+    fn constructor(
+        &self,
+        server: &mut Server,
+        session_id: &NodeId,
+        session_context: *mut c_void,
+        type_id: &NodeId,
+        type_context: *mut c_void,
+        node_id: &NodeId,
+    ) -> ua::StatusCode {
+        ua::StatusCode::GOOD
+    }
+
+    /// Destructor for a node where this `Lifecycle` was added to.
+    ///
+    /// Does nothing by default.
+    ///
+    /// Has a shared reference to self, so there is no need to worry
+    /// about thread-safety, if a struct implementing this trait
+    /// has fields.
+    #[allow(unused_variables)]
+    fn destructor(
+        &self,
+        server: &mut Server,
+        session_id: &NodeId,
+        session_context: *mut c_void,
+        type_id: &NodeId,
+        type_context: *mut c_void,
+        node_id: &NodeId,
+    ) {
+    }
+}

--- a/src/server/node_type_lifecycle_manager.rs
+++ b/src/server/node_type_lifecycle_manager.rs
@@ -1,0 +1,221 @@
+use crate::ua::{self, NodeTypeLifecycle};
+
+use crate::{server::Node, Attributes, NodeContext};
+
+use crate::{Error, Lifecycle, Result, Server};
+use std::sync::Arc;
+
+use open62541_sys::UA_NodeId;
+use open62541_sys::UA_Server;
+use open62541_sys::UA_StatusCode;
+
+use crate::DataType;
+use crate::ServerBuilder;
+
+use std::ffi::c_void;
+
+/// Wrapper for handling Node lifecycle
+///
+/// If you have created your own `VariableType` or `ObjectType`
+/// this may be the perfect fit for you. Using this wrapper,
+/// you can add a constructor and destructor to this type.
+/// These will be called when a Variable node or an Object node
+/// with your corresponding type gets created.
+/// To make use of this functionality view Usage below.
+///
+/// # Usage
+///
+/// * First call `LifecycleManager::init()` to crate an object.
+/// * Then use `LifecycleManager::with_type_node()` and
+///   `LifecycleManager::with_lifecycle()` to initialize the
+///   fields so you can call the following two methods.
+/// * To register your `Lifecycle` implementation on the server,
+///   run `LifecycleManager::server_set_node_type_lifecylce()`.
+/// * When you are then trying to add a new node with your
+///   `Node` type (`VariableType` or `ObjectType`) as type,
+///   make sure to use
+///   `LifecycleManager::server_add_node_with_lifecylce()`
+///   as the information for your constructor/destructor
+///   callbacks needs to be added to the node.
+/// * If you have used `Server::addNode()` instead by accident,
+///   the `Lifecycle` callbacks will not be called. And you'll
+///   be left with an error.
+///
+#[allow(clippy::struct_field_names)]
+pub struct LifecycleManager<'a> {
+    node_type_id: Option<&'a ua::NodeId>,
+    node_context: Option<NodeContext>,
+    node_type_lifecycle: Option<ua::NodeTypeLifecycle>,
+}
+
+impl<'a> LifecycleManager<'a> {
+    #[must_use]
+    pub const fn init() -> Self {
+        Self {
+            node_type_id: None,
+            node_context: None,
+            node_type_lifecycle: None,
+        }
+    }
+
+    /// Adds a `Node` with information on where to find the constructor and destructor
+    ///
+    /// # Errors
+    ///
+    /// This errors when `LifecycleManager::with_lifecycle()` has not yet been called
+    /// successfully or the `Node` could not be added.
+    pub fn server_add_node_with_lifecylce<T: Attributes>(
+        &self,
+        server: &Server,
+        mut node: Node<T>,
+    ) -> Result<()> {
+        // ARC count to the lifecycle trait impl increases by one here. View the
+        // definition of `NodeContext` for more information.
+        let node_context = self.node_context.clone().ok_or(Error::internal(
+            "node_context is None. It mustn't be to add the node!
+            Consider calling `LifecycleManager::with_lifecycle()`!",
+        ))?;
+        node.context = Some(node_context);
+        server.add_node(node)?;
+        Ok(())
+    }
+
+    /// Adds `Lifecycle` constructor / deconstructor to the `Node` type
+    ///
+    /// # Errors
+    ///
+    /// This errors either when `LifecycleManager::with_type_node()` and
+    /// `LifecycleManager::with_lifecycle()` have not yet been called
+    /// successfully or this function was called a second time.
+    pub fn server_set_node_type_lifecylce(mut self, server: &Server) -> Result<Self> {
+        let type_node_id: &ua::NodeId = self.node_type_id.ok_or(Error::internal(
+            "type_node_id is None. It mustn't be to set the lifecycle!
+            Consider calling `LifecycleManager::with_type_node()`!",
+        ))?;
+        let node_type_lifecycle: ua::NodeTypeLifecycle =
+            self.node_type_lifecycle.ok_or(Error::internal(
+                "node_type_li is None. It mustn't be to set the lifecycle!
+            Consider calling `LifecycleManager::with_lifecycle()`!",
+            ))?;
+        server.set_node_type_lifecycle(type_node_id, node_type_lifecycle);
+        self.node_type_lifecycle = None;
+        Ok(self)
+    }
+
+    /// Specify the type `NodeId` which will be used with this `LifecycleManager` object.
+    /// Returns the object which has the `NodeId` set.
+    #[must_use]
+    pub const fn with_type_node(mut self, node_type_id: &'a ua::NodeId) -> Self {
+        self.node_type_id = Some(node_type_id);
+        self
+    }
+
+    /// Specify the `Lifecycle` trait implementation which will be used with this
+    /// `LifecycleManager` object.
+    /// Returns the object which has the `Lifecycle` trait implementation set.
+    /// Internally this sets up the `NodeContext` with the extern C functions that
+    /// call the functions on the given `Lifecycle` trait implementation.
+    #[must_use]
+    pub fn with_lifecycle(
+        mut self,
+        lifecycle: (impl Lifecycle + 'static + std::marker::Send + std::marker::Sync),
+    ) -> Self {
+        unsafe extern "C" fn constructor_c(
+            server: *mut UA_Server,
+            session_id: *const UA_NodeId,
+            session_context: *mut c_void,
+            type_node_id: *const UA_NodeId,
+            type_node_context: *mut c_void,
+            node_id: *const UA_NodeId,
+            node_context: *mut *mut c_void,
+        ) -> UA_StatusCode {
+            let node_context = unsafe { NodeContext::peek_at(*node_context) };
+            let NodeContext::Lifecycle(lifecycle) = node_context else {
+                log::error!("Could not convert from *mut *mut c_void to Rust `NodeContext::Lifecycle`! \
+                Consider using `LifecycleManager::server_add_node_with_lifecylce()` to add the node to the server. \
+                This will make sure the correct NodeContext is passed. \
+                There is also a chance that some memory problem occurred.");
+                // We expect to always find this node context type.
+                return ua::StatusCode::BADINTERNALERROR.into_raw();
+            };
+
+            let mut server =
+                unsafe { ServerBuilder::from_raw_server(server.as_mut().unwrap_unchecked()) };
+
+            // We expect the passed parameters to be valid. If they aren't, something went wrong badly and we
+            // panic here.
+            let panic_str = "Invalid parameters passed to the callback. Callback failed!";
+
+            let status_code = unsafe {
+                lifecycle.constructor(
+                    &mut server,
+                    &ua::NodeId::clone_raw(session_id.as_ref().expect(panic_str)),
+                    session_context,
+                    &ua::NodeId::clone_raw(type_node_id.as_ref().expect(panic_str)),
+                    type_node_context,
+                    &ua::NodeId::clone_raw(node_id.as_ref().expect(panic_str)),
+                )
+            };
+
+            // Forget the server so we don't call the destructor on it
+            // We only constructed it so we have access to it, the server
+            // should still be valid after this callback.
+            std::mem::forget(server);
+
+            status_code.into_raw()
+        }
+
+        unsafe extern "C" fn destructor_c(
+            server: *mut UA_Server,
+            session_id: *const UA_NodeId,
+            session_context: *mut c_void,
+            type_node_id: *const UA_NodeId,
+            type_node_context: *mut c_void,
+            node_id: *const UA_NodeId,
+            node_context: *mut *mut c_void,
+        ) {
+            let node_context = unsafe { NodeContext::peek_at(*node_context) };
+            #[allow(irrefutable_let_patterns)] // We will add more node context types eventually.
+            let NodeContext::Lifecycle(lifecycle) = node_context
+            else {
+                log::error!(
+                    "Could not convert from *mut *mut c_void to Rust `NodeContext::Lifecycle`! \
+                    If the constructor ran successfully: Maybe the memory where `NodeContext::Lifecycle` \
+                    was stored is invalid now?"
+                );
+                panic!("Destructor failed! View the log for more details!");
+            };
+
+            // We expect the passed parameters to be valid. If they aren't, something went wrong badly and we
+            // panic here.
+            let panic_str = "Invalid parameters passed to the callback. Callback failed!";
+
+            unsafe {
+                lifecycle.destructor(
+                    &mut ServerBuilder::from_raw_server(server.as_mut().unwrap_unchecked()),
+                    &ua::NodeId::clone_raw(session_id.as_ref().expect(panic_str)),
+                    session_context,
+                    &ua::NodeId::clone_raw(type_node_id.as_ref().expect(panic_str)),
+                    type_node_context,
+                    &ua::NodeId::clone_raw(node_id.as_ref().expect(panic_str)),
+                );
+            };
+
+            // The ARC to node_context could be decreased here by 1 but is not
+            // necessary and could introduce unsafety. It isn't necessary as the
+            // memory for the rust con/destructor has static lifetime.
+        }
+
+        self.node_type_lifecycle = Some(
+            NodeTypeLifecycle::init()
+                .with_constructor(constructor_c)
+                .with_destructor(destructor_c),
+        );
+
+        // ARC to lifecycle trait impl is created here. View the
+        // definition of `NodeContext` for more information.
+        self.node_context = Some(NodeContext::Lifecycle(Arc::new(lifecycle)));
+
+        self
+    }
+}

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -38,6 +38,7 @@ mod node_attributes;
 mod node_class;
 mod node_id;
 mod node_id_type;
+mod node_type_lifecycle;
 mod qualified_name;
 mod read_request;
 mod read_response;
@@ -96,6 +97,7 @@ pub use self::{
     node_class::NodeClass,
     node_id::NodeId,
     node_id_type::NodeIdType,
+    node_type_lifecycle::NodeTypeLifecycle,
     qualified_name::QualifiedName,
     read_request::ReadRequest,
     read_response::ReadResponse,

--- a/src/ua/data_types/node_type_lifecycle.rs
+++ b/src/ua/data_types/node_type_lifecycle.rs
@@ -1,0 +1,123 @@
+use core::ffi::c_void;
+use open62541_sys::{UA_NodeId, UA_Server, UA_StatusCode};
+
+// Does not work as there is no UA_TYPES_NODETYPELIFECYCLE (bug in open62541?)
+// crate::data_type!(NodeTypeLifecycle);
+
+// For now let's use the expanded macro:
+/// Wrapper for
+///[`UA_NodeTypeLifecycle`](open62541_sys::UA_NodeTypeLifecycle)
+/// from [`open62541_sys`].
+///
+/// This owns the wrapped data. When the wrapper is dropped, the inner value is cleaned up
+/// with [`UA_clear()`] to release dynamically allocated memory held by the value.
+///
+/// [`UA_clear()`]: open62541_sys::UA_clear
+#[repr(transparent)]
+pub struct NodeTypeLifecycle(
+    /// Inner value.
+    open62541_sys::UA_NodeTypeLifecycle,
+);
+unsafe impl Send for NodeTypeLifecycle {}
+unsafe impl Sync for NodeTypeLifecycle {}
+impl Drop for NodeTypeLifecycle {
+    fn drop(&mut self) {
+        unsafe {
+            open62541_sys::UA_clear(
+                std::ptr::addr_of_mut!(self.0).cast::<std::ffi::c_void>(),
+                <Self as crate::DataType>::data_type(),
+            );
+        }
+    }
+}
+unsafe impl crate::DataType for NodeTypeLifecycle {
+    type Inner = open62541_sys::UA_NodeTypeLifecycle;
+    fn data_type() -> *const open62541_sys::UA_DataType {
+        // let index = usize::try_from(open62541_sys::UA_TYPES_NODETYPELIFECYCLE).unwrap();
+        // unsafe { open62541_sys::UA_TYPES.get(index) }.unwrap()
+        panic!(
+            "Cannot call data_type() with NodeTypeLifecycle right now as
+            UA_TYPES_NODETYPELIFECYCLE  does not exist in open62541."
+        )
+    }
+    #[must_use]
+    unsafe fn from_raw(src: Self::Inner) -> Self {
+        NodeTypeLifecycle(src)
+    }
+    #[must_use]
+    fn into_raw(self) -> Self::Inner {
+        let inner = unsafe { std::ptr::read(std::ptr::addr_of!(self.0)) };
+        std::mem::forget(self);
+        inner
+    }
+}
+impl Clone for NodeTypeLifecycle {
+    fn clone(&self) -> Self {
+        <Self as crate::DataType>::clone_raw(&self.0)
+    }
+}
+impl std::fmt::Debug for NodeTypeLifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = <Self as crate::DataType>::print(self);
+        let string = output.as_ref().and_then(|output| output.as_str());
+        f.write_str(string.unwrap_or("NodeTypeLifecycle"))
+    }
+}
+impl std::cmp::PartialEq for NodeTypeLifecycle {
+    fn eq(&self, other: &Self) -> bool {
+        <Self as std::cmp::Ord>::cmp(self, other) == std::cmp::Ordering::Equal
+    }
+}
+impl std::cmp::Eq for NodeTypeLifecycle {}
+impl std::cmp::PartialOrd for NodeTypeLifecycle {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(<Self as std::cmp::Ord>::cmp(self, other))
+    }
+}
+impl std::cmp::Ord for NodeTypeLifecycle {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let result = <Self as crate::DataType>::order(self, other);
+        match result {
+            open62541_sys::UA_Order::UA_ORDER_LESS => std::cmp::Ordering::Less,
+            open62541_sys::UA_Order::UA_ORDER_EQ => std::cmp::Ordering::Equal,
+            open62541_sys::UA_Order::UA_ORDER_MORE => std::cmp::Ordering::Greater,
+            _ => {
+                panic!("should return valid order");
+            }
+        }
+    }
+}
+
+pub type ConstructorFn = unsafe extern "C" fn(
+    server: *mut UA_Server,
+    session_id: *const UA_NodeId,
+    session_context: *mut c_void,
+    type_node_id: *const UA_NodeId,
+    type_node_context: *mut c_void,
+    node_id: *const UA_NodeId,
+    node_context: *mut *mut c_void,
+) -> UA_StatusCode;
+
+pub type DestructorFn = unsafe extern "C" fn(
+    server: *mut UA_Server,
+    session_id: *const UA_NodeId,
+    session_context: *mut c_void,
+    type_node_id: *const UA_NodeId,
+    type_node_context: *mut c_void,
+    node_id: *const UA_NodeId,
+    node_context: *mut *mut c_void,
+);
+
+impl NodeTypeLifecycle {
+    #[must_use]
+    pub fn with_constructor(mut self, constructor: ConstructorFn) -> Self {
+        self.0.constructor = Some(constructor);
+        self
+    }
+
+    #[must_use]
+    pub fn with_destructor(mut self, destructor: DestructorFn) -> Self {
+        self.0.destructor = Some(destructor);
+        self
+    }
+}

--- a/src/ua/server.rs
+++ b/src/ua/server.rs
@@ -31,6 +31,13 @@ impl Server {
         Self(inner)
     }
 
+    #[allow(dead_code)] // This will be used in the future
+    pub(crate) fn from_raw(raw_server: *mut UA_Server) -> Self {
+        // PANIC: The only possible errors here are out-of-memory.
+        let inner = NonNull::new(raw_server).expect("create UA_Server");
+        Self(inner)
+    }
+
     /// Returns const pointer to value.
     ///
     /// # Safety


### PR DESCRIPTION
This requires #138

This is used to add a Lifecycle to a node. This includes a constructor and a destructor, which are called on creation and on deletion of the node.

To be able to not expose the `NodeContext` to the user of the crate, a `LifecycleManager` was implemented, which wraps around the necessary steps to set a constructor and destructor for a object type. 
As the `NodeContext` needs to be passed when the node is added, `LifecycleManager` provides a interface for adding the node with the context too.