### PR TITLE
Implement reading server node attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add methods `Server::create_event()` and `Server::trigger_event()`.
 - Add methods `Server::browse()`, `Server::browse_next()`, `Server::browse_recursive()`, and
   `Server::browse_simplified_browse_path()`.
+- Add method `Server::read_attribute()` to read node attributes in a type-safe way.
 
 ### Changed
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use open62541::{ua, ObjectNode, Server, VariableNode};
+use open62541::{ua, Attribute, ObjectNode, Server, VariableNode};
 use open62541_sys::{
     UA_NS0ID_BASEDATAVARIABLETYPE, UA_NS0ID_FOLDERTYPE, UA_NS0ID_OBJECTSFOLDER, UA_NS0ID_ORGANIZES,
     UA_NS0ID_STRING,
@@ -41,6 +41,15 @@ fn main() -> anyhow::Result<()> {
     server.add_variable_node(variable_node)?;
 
     server.write_variable_string(&variable_node_id, "foobar")?;
+
+    read_attribute(&server, &variable_node_id, ua::AttributeId::NODEID_T)?;
+    read_attribute(&server, &variable_node_id, ua::AttributeId::NODECLASS_T)?;
+    read_attribute(&server, &variable_node_id, ua::AttributeId::BROWSENAME_T)?;
+    read_attribute(&server, &variable_node_id, ua::AttributeId::DISPLAYNAME_T)?;
+
+    for attribute in [ua::AttributeId::DESCRIPTION, ua::AttributeId::WRITEMASK] {
+        read_attribute(&server, &variable_node_id, &attribute)?;
+    }
 
     let (cancel_tx, cancel_rx) = mpsc::channel();
 
@@ -89,6 +98,18 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("Done");
+
+    Ok(())
+}
+
+fn read_attribute(
+    server: &Server,
+    node_id: &ua::NodeId,
+    attribute: impl Attribute,
+) -> anyhow::Result<()> {
+    let value = server.read_attribute(node_id, attribute)?;
+
+    println!("- attribute {attribute:?} has value {value:?}");
 
     Ok(())
 }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -249,7 +249,7 @@ impl AsyncClient {
             .collect();
 
         let request = ua::ReadRequest::init()
-            // We do return and therefore do not request timestamps now.
+            // We don't return and thus don't have to fetch timestamps.
             .with_timestamps_to_return(ua::TimestampsToReturn::NEITHER)
             .with_nodes_to_read(&nodes_to_read);
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -250,7 +250,7 @@ impl AsyncClient {
 
         let request = ua::ReadRequest::init()
             // We don't return and thus don't have to fetch timestamps.
-            .with_timestamps_to_return(ua::TimestampsToReturn::NEITHER)
+            .with_timestamps_to_return(&ua::TimestampsToReturn::NEITHER)
             .with_nodes_to_read(&nodes_to_read);
 
         let response = service_request(&self.client, request).await?;

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -248,7 +248,10 @@ impl AsyncClient {
             })
             .collect();
 
-        let request = ua::ReadRequest::init().with_nodes_to_read(&nodes_to_read);
+        let request = ua::ReadRequest::init()
+            // We do return and therefore do not request timestamps now.
+            .with_timestamps_to_return(ua::TimestampsToReturn::NEITHER)
+            .with_nodes_to_read(&nodes_to_read);
 
         let response = service_request(&self.client, request).await?;
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,0 +1,58 @@
+use crate::{ua, Attribute};
+
+macro_rules! attribute_impl {
+    ($( ($name:ident, $value:ident) ),* $(,)?) => {
+        $(
+            #[derive(Debug, Clone, Copy)]
+            pub struct $name;
+
+            impl $crate::Attribute for $name {
+                type Value = $crate::ua::$value;
+
+                fn id(&self) -> $crate::ua::AttributeId {
+                    paste::paste! {
+                        $crate::ua::AttributeId::[<$name:upper>]
+                    }
+                }
+            }
+
+            impl $crate::ua::AttributeId {
+                paste::paste! {
+                    pub const [<$name:upper _T>]: $crate::attributes::$name =
+                        $crate::attributes::$name;
+                }
+            }
+        )*
+    };
+}
+
+attribute_impl!(
+    (NodeId, NodeId),
+    (NodeClass, NodeClass),
+    (BrowseName, QualifiedName),
+    (DisplayName, LocalizedText),
+    (Description, LocalizedText),
+    (WriteMask, UInt32),
+    (IsAbstract, Boolean),
+    (Symmetric, Boolean),
+    (InverseName, LocalizedText),
+    (ContainsNoLoops, Boolean),
+    (EventNotifier, Byte),
+    (Value, Variant),
+    (DataType, NodeId),
+    (ValueRank, UInt32),
+    (ArrayDimensions, Variant),
+    (AccessLevel, Byte),
+    (AccessLevelEx, UInt32),
+    (MinimumSamplingInterval, Double),
+    (Historizing, Boolean),
+    (Executable, Boolean),
+);
+
+impl Attribute for &ua::AttributeId {
+    type Value = ua::Variant;
+
+    fn id(&self) -> ua::AttributeId {
+        (*self).clone()
+    }
+}

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -18,6 +18,8 @@ macro_rules! attribute_impl {
 
             impl $crate::ua::AttributeId {
                 paste::paste! {
+                    /// Implementation of [`crate::Attribute`] for
+                    #[doc = concat!("[`", stringify!([<$name:upper>]), "`](Self::", stringify!([<$name:upper>]), ").")]
                     pub const [<$name:upper _T>]: $crate::attributes::$name =
                         $crate::attributes::$name;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ mod async_client;
 mod async_monitored_item;
 #[cfg(feature = "tokio")]
 mod async_subscription;
+mod attributes;
 #[cfg(feature = "tokio")]
 mod callback;
 mod logger;
@@ -91,7 +92,7 @@ pub use self::{
         DataSourceWriteContext, Node, ObjectNode, Server, ServerBuilder, ServerRunner,
         VariableNode,
     },
-    traits::Attributes,
+    traits::{Attribute, Attributes},
     userdata::Userdata,
     value::{ScalarValue, ValueType, VariantValue},
 };

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,12 +13,13 @@ use open62541_sys::{
     UA_Server_addNamespace, UA_Server_addReference, UA_Server_browse, UA_Server_browseNext,
     UA_Server_browseRecursive, UA_Server_browseSimplifiedBrowsePath, UA_Server_createEvent,
     UA_Server_deleteNode, UA_Server_deleteReference, UA_Server_getNamespaceByIndex,
-    UA_Server_getNamespaceByName, UA_Server_readObjectProperty, UA_Server_runUntilInterrupt,
-    UA_Server_translateBrowsePathToNodeIds, UA_Server_triggerEvent, UA_Server_writeObjectProperty,
-    __UA_Server_addNode, __UA_Server_write, UA_STATUSCODE_BADNOTFOUND,
+    UA_Server_getNamespaceByName, UA_Server_read, UA_Server_readObjectProperty,
+    UA_Server_runUntilInterrupt, UA_Server_translateBrowsePathToNodeIds, UA_Server_triggerEvent,
+    UA_Server_writeObjectProperty, __UA_Server_addNode, __UA_Server_write,
+    UA_STATUSCODE_BADNOTFOUND,
 };
 
-use crate::{ua, Attributes, DataType, Error, Result};
+use crate::{ua, Attribute, Attributes, DataType, Error, Result};
 
 pub(crate) use self::node_context::NodeContext;
 pub use self::{
@@ -920,6 +921,73 @@ impl Server {
             .targets()
             .ok_or(Error::internal("translation should return targets"))?;
         Ok(targets)
+    }
+
+    /// Reads node attribute.
+    ///
+    /// This method supports static dispatch to the correct value type at compile time and can be
+    /// used in two ways:
+    ///
+    /// 1. Use statically known attribute type `_T` from [`ua::AttributeId`] to get correct value
+    ///    type directly.
+    /// 2. Use dynamic [`ua::AttributeId`] value and handle the resulting [`ua::Variant`].
+    ///
+    /// # Errors
+    ///
+    /// This fails when the node does not exist or the attribute cannot be read.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use open62541::{DataType as _, ServerBuilder, ua};
+    /// # use open62541_sys::UA_NS0ID_SERVER_SERVERSTATUS;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// # let (server, _) = ServerBuilder::default().build();
+    /// #
+    /// let node_id = ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS);
+    ///
+    /// // Use static dispatch to get expected value type directly:
+    /// let browse_name = server.read_attribute(&node_id, ua::AttributeId::BROWSENAME_T)?;
+    /// // The type of `browse_name` is `ua::QualifiedName` here.
+    /// assert_eq!(browse_name, ua::QualifiedName::new(0, "ServerStatus"));
+    ///
+    /// // Use dynamic attribute and unwrap `ua::Variant` manually:
+    /// let attribute_id: ua::AttributeId = ua::AttributeId::BROWSENAME;
+    /// let browse_name = server.read_attribute(&node_id, &attribute_id)?;
+    /// // The type of `browse_name` is `ua::Variant` here.
+    /// let browse_name = browse_name.to_scalar::<ua::QualifiedName>().unwrap();
+    /// assert_eq!(browse_name, ua::QualifiedName::new(0, "ServerStatus"));
+    /// #
+    /// # let unknown_node_id = ua::NodeId::ns0(123_456_789);
+    /// # assert!(server.read_attribute(&unknown_node_id, ua::AttributeId::NODEID_T).is_err());
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read_attribute<T: Attribute>(
+        &self,
+        node_id: &ua::NodeId,
+        attribute: T,
+    ) -> Result<T::Value> {
+        let item = ua::ReadValueId::init()
+            .with_node_id(node_id)
+            .with_attribute_id(&attribute.id());
+        let result = unsafe {
+            ua::DataValue::from_raw(UA_Server_read(
+                self.0.as_ptr().cast_mut(),
+                item.as_ptr(),
+                ua::TimestampsToReturn::NEITHER.into_raw(),
+            ))
+        };
+        // By convention, `open62541` only sets status code when something went wrong.
+        Error::verify_good(&result.status_code().unwrap_or(ua::StatusCode::GOOD))?;
+        let value = result.value().ok_or(Error::internal("missing value"))?;
+        let value = value
+            .as_scalar::<T::Value>()
+            .ok_or(Error::internal("unexpected data type"))?;
+        Ok(value.clone())
     }
 
     /// Writes value to variable node.

--- a/src/server.rs
+++ b/src/server.rs
@@ -985,9 +985,9 @@ impl Server {
         Error::verify_good(&result.status_code().unwrap_or(ua::StatusCode::GOOD))?;
         let value = result.value().ok_or(Error::internal("missing value"))?;
         let value = value
-            .as_scalar::<T::Value>()
+            .to_scalar::<T::Value>()
             .ok_or(Error::internal("unexpected data type"))?;
-        Ok(value.clone())
+        Ok(value)
     }
 
     /// Writes value to variable node.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,28 @@
+use std::fmt;
+
 use open62541_sys::UA_DataType;
 
 use crate::{ua, DataType};
 
+/// Node attribute.
+///
+/// This is used to match the appropriate result types at compile time when reading attributes from
+/// nodes. See the following methods for details:
+///
+/// - [`AsyncClient::read_attribute()`](crate::AsyncClient::read_attribute)
+/// - [`Server::read_attribute()`](crate::Server::read_attribute)
+pub trait Attribute: fmt::Debug + Copy {
+    /// Attribute data type.
+    type Value: DataType;
+
+    /// Gets attribute ID.
+    fn id(&self) -> ua::AttributeId;
+}
+
+/// Server node attributes.
+///
+/// This is used to allow handling different node types when adding nodes to the server's data tree
+/// in [`Server::add_node()`](crate::Server::add_node).
 pub trait Attributes: DataType {
     /// Gets associated node class.
     fn node_class(&self) -> ua::NodeClass;

--- a/src/ua/data_types/read_request.rs
+++ b/src/ua/data_types/read_request.rs
@@ -6,9 +6,9 @@ impl ReadRequest {
     #[must_use]
     pub fn with_timestamps_to_return(
         mut self,
-        timestamps_to_return: ua::TimestampsToReturn,
+        timestamps_to_return: &ua::TimestampsToReturn,
     ) -> Self {
-        timestamps_to_return.move_into_raw(&mut self.0.timestampsToReturn);
+        timestamps_to_return.clone_into_raw(&mut self.0.timestampsToReturn);
         self
     }
 

--- a/src/ua/data_types/read_request.rs
+++ b/src/ua/data_types/read_request.rs
@@ -1,8 +1,17 @@
-use crate::{ua, ServiceRequest};
+use crate::{ua, DataType as _, ServiceRequest};
 
 crate::data_type!(ReadRequest);
 
 impl ReadRequest {
+    #[must_use]
+    pub fn with_timestamps_to_return(
+        mut self,
+        timestamps_to_return: ua::TimestampsToReturn,
+    ) -> Self {
+        timestamps_to_return.move_into_raw(&mut self.0.timestampsToReturn);
+        self
+    }
+
     #[must_use]
     pub fn with_nodes_to_read(mut self, nodes_to_read: &[ua::ReadValueId]) -> Self {
         let array = ua::Array::from_slice(nodes_to_read);

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -86,23 +86,17 @@ impl Variant {
 
     #[must_use]
     pub fn as_scalar<T: DataType>(&self) -> Option<&T> {
-        let data = if unsafe { UA_Variant_hasScalarType(self.as_ptr(), T::data_type()) } {
-            unsafe { self.0.data.cast::<T::Inner>().as_ref() }
-        } else {
-            if T::data_type() != Self::data_type() {
-                return None;
-            }
-            // If type conversion to `ua::Variant` is requested, we fall back to `self` as-is (OPC
-            // UA specifies that variants cannot directly contain other variants; we use this here
-            // to simplify unwrapping in generic code).
-            unsafe { self.as_ptr().cast::<T::Inner>().as_ref() }
-        };
-        data.map(|value| T::raw_ref(value))
+        self.scalar_data::<T>().map(T::raw_ref)
     }
 
     #[must_use]
     pub fn to_scalar<T: DataType>(&self) -> Option<T> {
-        let data = if unsafe { UA_Variant_hasScalarType(self.as_ptr(), T::data_type()) } {
+        self.scalar_data::<T>().map(T::clone_raw)
+    }
+
+    #[must_use]
+    fn scalar_data<T: DataType>(&self) -> Option<&T::Inner> {
+        if unsafe { UA_Variant_hasScalarType(self.as_ptr(), T::data_type()) } {
             unsafe { self.0.data.cast::<T::Inner>().as_ref() }
         } else {
             if T::data_type() != Self::data_type() {
@@ -110,10 +104,9 @@ impl Variant {
             }
             // If type conversion to `ua::Variant` is requested, we fall back to `self` as-is (OPC
             // UA specifies that variants cannot directly contain other variants; we use this here
-            // to simplify unwrapping in generic code).
+            // to allow idempotent unwrapping which is useful in generic code).
             unsafe { self.as_ptr().cast::<T::Inner>().as_ref() }
-        };
-        data.map(|value| T::clone_raw(value))
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
## Description

This is an alternative to #146 and proposes a slightly more idiomatic approach that does not require a macro at the call site to implement type-safe reading of node attributes.

When this is implemented, we could use the same approach and refactor `AsyncClient::read_attribute()` and all related methods in a similar way.