### PR TITLE
Return typed attribute value from client read operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade to open62541 released version 1.4.3.
 - Breaking: Change signatures of `AsyncClient::browse()` and `AsyncClient::browse_many()` to accept
   `ua::BrowseDescription` instead of `ua::NodeId` for better control over the resulting references.
+- Breaking: Return typed variant `DataValue` instead of `ua::DataValue` from `AsyncClient` read
+  operations.
 
 ## [0.6.0-pre.5] - 2024-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add methods `Server::browse()`, `Server::browse_next()`, `Server::browse_recursive()`, and
   `Server::browse_simplified_browse_path()`.
 - Add method `Server::read_attribute()` to read node attributes in a type-safe way.
+- Add methods to `ua::DataValue` to get source/server timestamps.
 
 ### Changed
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -208,7 +208,6 @@ fn get_arguments(value: &DataValue<ua::Variant>) -> anyhow::Result<Vec<(ua::Stri
 
     let arguments = value
         .value()
-        .ok_or(anyhow::anyhow!("should have value"))?
         .to_array::<ua::Argument>()
         .ok_or(anyhow::anyhow!("should have array"))?;
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use open62541::{ua, AsyncClient, ValueType};
+use open62541::{ua, AsyncClient, DataValue, ValueType};
 use open62541_sys::{UA_NS0ID_HASPROPERTY, UA_NS0ID_PROPERTYTYPE};
 
 #[tokio::main]
@@ -168,7 +168,7 @@ async fn get_definition(
 async fn read_sparse_node_values(
     client: &AsyncClient,
     node_ids: &[Option<ua::NodeId>],
-) -> anyhow::Result<Vec<Option<ua::DataValue>>> {
+) -> anyhow::Result<Vec<Option<DataValue<ua::Variant>>>> {
     // Condense sparse list into dense list for request.
     let node_attributes: Vec<_> = node_ids
         .iter()
@@ -202,7 +202,7 @@ async fn read_sparse_node_values(
 ///
 /// This looks into the value returned from reading `InputArguments` and `OutputArguments` property
 /// and returns the list of argument names and their value types.
-fn get_arguments(value: &ua::DataValue) -> anyhow::Result<Vec<(ua::String, ValueType)>> {
+fn get_arguments(value: &DataValue<ua::Variant>) -> anyhow::Result<Vec<(ua::String, ValueType)>> {
     // `InputArguments` and `OutputArguments` nodes are expected to hold an array of objects of the
     // `Argument` type.
 

--- a/examples/async_concurrent.rs
+++ b/examples/async_concurrent.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context as _};
+use anyhow::Context as _;
 use open62541::{ua, AsyncClient};
 use open62541_sys::{UA_NS0ID_SERVER, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME};
 use tokio::task::JoinSet;
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
                 .read_value(&ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME))
                 .await
                 .context("read")?;
-            let value = value.value().ok_or(anyhow!("no value"))?.to_value();
+            let value = value.value().to_value();
             println!("Value: {value:?}");
 
             Ok::<_, anyhow::Error>(())

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -51,10 +51,7 @@ async fn read_attributes(client: &AsyncClient, node_id: &ua::NodeId) -> anyhow::
 
     for (attribute_id, value) in ATTRIBUTE_IDS.iter().zip(attribute_values.iter()) {
         match value {
-            Ok(value) => match value.value() {
-                Some(value) => println!("- {attribute_id} -> {value:?}"),
-                None => println!("- {attribute_id} -> (no value)"),
-            },
+            Ok(value) => println!("- {attribute_id} -> {value:?}"),
             Err(err) => println!("- {attribute_id} -> {err}"),
         }
     }

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -38,10 +38,7 @@ async fn read_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
 
     println!(
         "Node {node_id} has value {:?}",
-        value
-            .value()
-            .and_then(ua::Variant::as_scalar)
-            .and_then(ua::DateTime::to_utc)
+        value.value().as_scalar().and_then(ua::DateTime::to_utc)
     );
 
     Ok(())

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -259,12 +259,7 @@ impl AsyncClient {
 
         let results: Vec<_> = results
             .iter()
-            .map(|result| -> Result<DataValue<ua::Variant>> {
-                // An unset status code is considered valid: servers are not required to include the
-                // status code in their response when not necessary.
-                Error::verify_good(&result.status_code().unwrap_or(ua::StatusCode::GOOD))?;
-                result.to_generic::<ua::Variant>()
-            })
+            .map(ua::DataValue::to_generic::<ua::Variant>)
             .collect();
 
         // The OPC UA specification state that the resulting list has the same number of elements as

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -189,7 +189,7 @@ impl AsyncClient {
         debug_assert_eq!(values.len(), 1);
         let value = values.pop().expect("should contain exactly one attribute");
 
-        value.and_then(DataValue::cast::<T::Value>)
+        value.and_then(DataValue::into_scalar::<T::Value>)
     }
 
     /// Reads several node attributes.

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -55,3 +55,31 @@ impl<T: DataType> DataValue<T> {
         self.server_picoseconds
     }
 }
+
+impl DataValue<ua::Variant> {
+    pub(crate) fn cast<T: DataType>(self) -> Result<DataValue<T>> {
+        let Self {
+            value,
+            source_timestamp,
+            server_timestamp,
+            source_picoseconds,
+            server_picoseconds,
+        } = self;
+
+        let value = value
+            .map(|value| {
+                value
+                    .to_scalar::<T>()
+                    .ok_or(Error::internal("unexpected data type"))
+            })
+            .transpose()?;
+
+        Ok(DataValue {
+            value,
+            source_timestamp,
+            server_timestamp,
+            source_picoseconds,
+            server_picoseconds,
+        })
+    }
+}

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -64,6 +64,7 @@ impl<T: DataType> DataValue<T> {
 }
 
 impl DataValue<ua::Variant> {
+    #[allow(dead_code)] // --no-default-features
     pub(crate) fn cast<T: DataType>(self) -> Result<DataValue<T>> {
         let Self {
             value,

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -64,8 +64,13 @@ impl<T: DataType> DataValue<T> {
 }
 
 impl DataValue<ua::Variant> {
+    /// Cast to specific value type.
+    ///
+    /// This consumes `self` and casts the inner value to the specified data type. This should be
+    /// used in situation where the expected type can be deduced from circumstances and unwrapped
+    /// data values are needed for convenience. This always expects a scalar value.
     #[allow(dead_code)] // --no-default-features
-    pub(crate) fn cast<T: DataType>(self) -> Result<DataValue<T>> {
+    pub(crate) fn into_scalar<T: DataType>(self) -> Result<DataValue<T>> {
         let Self {
             value,
             source_timestamp,

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -38,6 +38,11 @@ impl<T: DataType> DataValue<T> {
     }
 
     #[must_use]
+    pub fn into_value(self) -> T {
+        self.value
+    }
+
+    #[must_use]
     pub const fn source_timestamp(&self) -> Option<&ua::DateTime> {
         self.source_timestamp.as_ref()
     }

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -1,0 +1,57 @@
+use crate::{ua, DataType, Error, Result};
+
+/// Typed variant of [`ua::DataValue`].
+#[derive(Debug, Clone)]
+pub struct DataValue<T> {
+    value: Option<T>,
+    source_timestamp: Option<ua::DateTime>,
+    server_timestamp: Option<ua::DateTime>,
+    source_picoseconds: Option<u16>,
+    server_picoseconds: Option<u16>,
+}
+
+impl<T: DataType> DataValue<T> {
+    pub(crate) fn new(data_value: &ua::DataValue) -> Result<Self> {
+        let value = data_value
+            .value()
+            .map(|value| {
+                value
+                    .to_scalar::<T>()
+                    .ok_or(Error::internal("unexpected data type"))
+            })
+            .transpose()?;
+
+        Ok(Self {
+            value,
+            source_timestamp: data_value.source_timestamp().cloned(),
+            server_timestamp: data_value.server_timestamp().cloned(),
+            source_picoseconds: data_value.source_picoseconds(),
+            server_picoseconds: data_value.server_picoseconds(),
+        })
+    }
+
+    #[must_use]
+    pub const fn value(&self) -> Option<&T> {
+        self.value.as_ref()
+    }
+
+    #[must_use]
+    pub const fn source_timestamp(&self) -> Option<&ua::DateTime> {
+        self.source_timestamp.as_ref()
+    }
+
+    #[must_use]
+    pub const fn server_timestamp(&self) -> Option<&ua::DateTime> {
+        self.server_timestamp.as_ref()
+    }
+
+    #[must_use]
+    pub const fn source_picoseconds(&self) -> Option<u16> {
+        self.source_picoseconds
+    }
+
+    #[must_use]
+    pub const fn server_picoseconds(&self) -> Option<u16> {
+        self.server_picoseconds
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod async_subscription;
 mod attributes;
 #[cfg(feature = "tokio")]
 mod callback;
+mod data_value;
 mod logger;
 mod traits;
 mod userdata;
@@ -86,6 +87,7 @@ mod value;
 pub use self::{
     client::{Client, ClientBuilder},
     data_type::DataType,
+    data_value::DataValue,
     error::{Error, Result},
     server::{
         DataSource, DataSourceError, DataSourceReadContext, DataSourceResult,

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -1,4 +1,4 @@
-use crate::{ua, DataType as _};
+use crate::{ua, DataType, Result};
 
 crate::data_type!(DataValue);
 
@@ -74,5 +74,9 @@ impl DataValue {
         self.0
             .hasStatus()
             .then(|| ua::StatusCode::new(self.0.status))
+    }
+
+    pub(crate) fn to_generic<T: DataType>(&self) -> Result<crate::DataValue<T>> {
+        crate::DataValue::new(self)
     }
 }

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -42,6 +42,34 @@ impl DataValue {
     }
 
     #[must_use]
+    pub fn source_timestamp(&self) -> Option<&ua::DateTime> {
+        self.0
+            .hasSourceTimestamp()
+            .then(|| ua::DateTime::raw_ref(&self.0.sourceTimestamp))
+    }
+
+    #[must_use]
+    pub fn server_timestamp(&self) -> Option<&ua::DateTime> {
+        self.0
+            .hasServerTimestamp()
+            .then(|| ua::DateTime::raw_ref(&self.0.serverTimestamp))
+    }
+
+    #[must_use]
+    pub fn source_picoseconds(&self) -> Option<u16> {
+        self.0
+            .hasSourcePicoseconds()
+            .then_some(self.0.sourcePicoseconds)
+    }
+
+    #[must_use]
+    pub fn server_picoseconds(&self) -> Option<u16> {
+        self.0
+            .hasServerPicoseconds()
+            .then_some(self.0.serverPicoseconds)
+    }
+
+    #[must_use]
     pub fn status_code(&self) -> Option<ua::StatusCode> {
         self.0
             .hasStatus()


### PR DESCRIPTION
## Description

This PR uses the concepts from #150 to allow the type-safe reading of node attributes in `AsyncClient` as well. In addition, we introduce `DataValue<T>` as typed variant of `ua::DataValue` to return attribute values with timestamps.