### PR TITLE
Upgrade to open62541 version 1.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b75454e8ea68c910593aee3176e8368867351fe6ab6723f2d14d068dff4b4d3"
+checksum = "2b7f21b5140f3a7c415dda2701b2e9141a88d88c5f3c3b6d3ea38b547e690839"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.1"
+open62541-sys = "0.4.2"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest release of [open62541](https://github.com/open62541/open62541).