### PR TITLE
Refactor `Server` methods to match `AsyncClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   operations.
 - Breaking: Adjust signatures of `Server::add_object_node()` and `Server::add_variable_node()` to
   match the new methods, returning the inserted node IDs.
+- Breaking: Rename `Server::write_variable()` to `Server::write_value()` to better match client
+  interface.
+- Breaking: Remove special-cased helper method `Server::write_variable_string()`.
 
 ## [0.6.0-pre.5] - 2024-05-31
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -38,7 +38,10 @@ fn main() -> anyhow::Result<()> {
     };
     let variable_node_id = server.add_variable_node(variable_node)?;
 
-    server.write_variable_string(&variable_node_id, "foobar")?;
+    server.write_value(
+        &variable_node_id,
+        &ua::Variant::scalar(ua::String::new("foobar")?),
+    )?;
 
     read_attribute(&server, &variable_node_id, ua::AttributeId::NODEID_T)?;
     read_attribute(&server, &variable_node_id, ua::AttributeId::NODECLASS_T)?;
@@ -63,7 +66,10 @@ fn main() -> anyhow::Result<()> {
                     }
                     Err(RecvTimeoutError::Disconnected) => panic!("main task should be running"),
                 }
-                server.write_variable_string(&variable_node_id, value)?;
+                server.write_value(
+                    &variable_node_id,
+                    &ua::Variant::scalar(ua::String::new(value)?),
+                )?;
             }
         }
     });

--- a/src/server.rs
+++ b/src/server.rs
@@ -1137,12 +1137,12 @@ impl Server {
         result.to_generic::<T::Value>()
     }
 
-    /// Writes value to variable node.
+    /// Writes node value.
     ///
     /// # Errors
     ///
-    /// This fails when the variable node cannot be written.
-    pub fn write_variable(&self, node_id: &ua::NodeId, value: &ua::Variant) -> Result<()> {
+    /// This fails when the node does not exist or its value attribute cannot be written.
+    pub fn write_value(&self, node_id: &ua::NodeId, value: &ua::Variant) -> Result<()> {
         let status_code = ua::StatusCode::new(unsafe {
             __UA_Server_write(
                 // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
@@ -1155,32 +1155,6 @@ impl Server {
             )
         });
         Error::verify_good(&status_code)
-    }
-
-    /// Writes string value to variable node.
-    ///
-    /// This is a shortcut and roughly equivalent to the following:
-    ///
-    /// ```
-    /// # use open62541::{ua, DataType as _, Server};
-    /// #
-    /// # fn write_variable_string(
-    /// #     server: &mut Server,
-    /// #     node_id: &ua::NodeId,
-    /// #     value: &str,
-    /// # ) -> anyhow::Result<()> {
-    /// let value = ua::Variant::scalar(ua::String::new(value)?);
-    /// server.write_variable(node_id, &value)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// This fails when the variable node cannot be written.
-    pub fn write_variable_string(&self, node_id: &ua::NodeId, value: &str) -> Result<()> {
-        let ua_variant = ua::Variant::scalar(ua::String::new(value)?);
-        self.write_variable(node_id, &ua_variant)
     }
 
     /// Reads object property.


### PR DESCRIPTION
## Description

This renames `Server::write_variable()` to `write_value()`, to match the corresponding method in `AsyncClient`. It also removes the arbitrary helper method `Server::write_variable_string()`. The same effect can be achieved more explicitly.