### PR TITLE
Add support for setting user identity token before connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add method `ClientBuilder::user_identity_token()` and associated types to set user identity token.
+
 ## [0.6.0] - 2024-08-20
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets user identity token.
+    #[must_use]
+    pub fn user_identity_token(mut self, user_identity_token: &ua::UserIdentityToken) -> Self {
+        user_identity_token
+            .to_extension_object()
+            .move_into_raw(&mut self.config_mut().userIdentityToken);
+        self
+    }
+
     /// Sets secure channel life time.
     ///
     /// After this life time, the channel needs to be renewed.

--- a/src/ua.rs
+++ b/src/ua.rs
@@ -16,6 +16,7 @@ mod server_config;
 mod session_state;
 mod specified_attributes;
 mod subscription_id;
+mod user_identity_token;
 
 pub use self::{
     access_level::AccessLevel,
@@ -32,5 +33,6 @@ pub use self::{
     session_state::SessionState,
     specified_attributes::SpecifiedAttributes,
     subscription_id::SubscriptionId,
+    user_identity_token::UserIdentityToken,
 };
 pub(crate) use self::{client_config::ClientConfig, server_config::ServerConfig};

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -1,5 +1,6 @@
 //! Thin wrappers for OPC UA data types from [`open62541_sys`].
 
+mod anonymous_identity_token;
 mod application_description;
 mod application_type;
 mod argument;
@@ -48,12 +49,14 @@ mod relative_path_element;
 mod status_code;
 mod string;
 mod timestamps_to_return;
+mod user_name_identity_token;
 mod variant;
 mod write_request;
 mod write_response;
 mod write_value;
 
 pub use self::{
+    anonymous_identity_token::AnonymousIdentityToken,
     application_description::ApplicationDescription,
     application_type::ApplicationType,
     argument::Argument,
@@ -106,6 +109,7 @@ pub use self::{
     status_code::StatusCode,
     string::String,
     timestamps_to_return::TimestampsToReturn,
+    user_name_identity_token::UserNameIdentityToken,
     variant::Variant,
     write_request::WriteRequest,
     write_response::WriteResponse,

--- a/src/ua/data_types/anonymous_identity_token.rs
+++ b/src/ua/data_types/anonymous_identity_token.rs
@@ -1,0 +1,1 @@
+crate::data_type!(AnonymousIdentityToken);

--- a/src/ua/data_types/user_name_identity_token.rs
+++ b/src/ua/data_types/user_name_identity_token.rs
@@ -1,0 +1,38 @@
+use crate::{ua, DataType as _};
+
+crate::data_type!(UserNameIdentityToken);
+
+impl UserNameIdentityToken {
+    #[must_use]
+    pub fn new(user_name: &str, password: &str) -> Self {
+        Self::init()
+            .with_user_name(user_name)
+            .with_password(password)
+    }
+
+    /// Sets user name.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
+    #[must_use]
+    pub fn with_user_name(mut self, user_name: &str) -> Self {
+        ua::String::new(user_name)
+            .unwrap()
+            .move_into_raw(&mut self.0.userName);
+        self
+    }
+
+    /// Sets password.
+    ///
+    /// # Panics
+    ///
+    /// The string must not contain any NUL bytes.
+    #[must_use]
+    pub fn with_password(mut self, password: &str) -> Self {
+        ua::String::new(password)
+            .unwrap()
+            .move_into_raw(&mut self.0.password);
+        self
+    }
+}

--- a/src/ua/user_identity_token.rs
+++ b/src/ua/user_identity_token.rs
@@ -1,0 +1,27 @@
+use crate::ua;
+
+pub enum UserIdentityToken {
+    Anonymous(ua::AnonymousIdentityToken),
+    UserName(ua::UserNameIdentityToken),
+}
+
+impl UserIdentityToken {
+    pub(crate) fn to_extension_object(&self) -> ua::ExtensionObject {
+        match self {
+            UserIdentityToken::Anonymous(anonymous) => ua::ExtensionObject::new(anonymous),
+            UserIdentityToken::UserName(user_name) => ua::ExtensionObject::new(user_name),
+        }
+    }
+}
+
+impl From<ua::AnonymousIdentityToken> for UserIdentityToken {
+    fn from(value: ua::AnonymousIdentityToken) -> Self {
+        Self::Anonymous(value)
+    }
+}
+
+impl From<ua::UserNameIdentityToken> for UserIdentityToken {
+    fn from(value: ua::UserNameIdentityToken) -> Self {
+        Self::UserName(value)
+    }
+}


### PR DESCRIPTION
## Description

This adds support for connecting to OPC UA servers with non-anonymous user identity token, e.g.

```rust
let client = ClientBuilder::default()
    .user_identity_token(&ua::UserNameIdentityToken::new("user_name", "password").into())
    .connect("opc.tcp://127.0.0.1:4840")
    .context("connect")?
    .into_async();
```