### PR TITLE
Fix Clippy lints with Rust 1.81

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::bail;
 use open62541::{ua, Attribute, ObjectNode, Server, VariableNode};
 use open62541_sys::{
     UA_NS0ID_BASEDATAVARIABLETYPE, UA_NS0ID_FOLDERTYPE, UA_NS0ID_OBJECTSFOLDER, UA_NS0ID_ORGANIZES,
@@ -64,7 +65,7 @@ fn main() -> anyhow::Result<()> {
                     Err(RecvTimeoutError::Timeout) => {
                         // Continue and simulate next updated value below, then repeat loop.
                     }
-                    Err(RecvTimeoutError::Disconnected) => panic!("main task should be running"),
+                    Err(RecvTimeoutError::Disconnected) => bail!("main task should be running"),
                 }
                 server.write_value(
                     &variable_node_id,

--- a/src/ua/data_types/argument.rs
+++ b/src/ua/data_types/argument.rs
@@ -16,7 +16,7 @@ impl Argument {
     }
 
     #[must_use]
-    pub fn with_value_rank(mut self, value_rank: i32) -> Self {
+    pub const fn with_value_rank(mut self, value_rank: i32) -> Self {
         self.0.valueRank = value_rank;
         self
     }

--- a/src/ua/data_types/browse_description.rs
+++ b/src/ua/data_types/browse_description.rs
@@ -24,19 +24,19 @@ impl BrowseDescription {
     }
 
     #[must_use]
-    pub fn with_include_subtypes(mut self, include_subtypes: bool) -> Self {
+    pub const fn with_include_subtypes(mut self, include_subtypes: bool) -> Self {
         self.0.includeSubtypes = include_subtypes;
         self
     }
 
     #[must_use]
-    pub fn with_node_class_mask(mut self, node_class_mask: &ua::NodeClassMask) -> Self {
+    pub const fn with_node_class_mask(mut self, node_class_mask: &ua::NodeClassMask) -> Self {
         self.0.nodeClassMask = node_class_mask.as_u32();
         self
     }
 
     #[must_use]
-    pub fn with_result_mask(mut self, result_mask: &ua::BrowseResultMask) -> Self {
+    pub const fn with_result_mask(mut self, result_mask: &ua::BrowseResultMask) -> Self {
         self.0.resultMask = result_mask.as_u32();
         self
     }

--- a/src/ua/data_types/browse_next_request.rs
+++ b/src/ua/data_types/browse_next_request.rs
@@ -21,7 +21,10 @@ impl BrowseNextRequest {
     }
 
     #[must_use]
-    pub fn with_release_continuation_points(mut self, release_continuation_points: bool) -> Self {
+    pub const fn with_release_continuation_points(
+        mut self,
+        release_continuation_points: bool,
+    ) -> Self {
         self.0.releaseContinuationPoints = release_continuation_points;
         self
     }

--- a/src/ua/data_types/browse_request.rs
+++ b/src/ua/data_types/browse_request.rs
@@ -11,7 +11,7 @@ impl BrowseRequest {
     }
 
     #[must_use]
-    pub fn with_requested_max_references_per_node(
+    pub const fn with_requested_max_references_per_node(
         mut self,
         requested_max_references_per_node: u32,
     ) -> Self {

--- a/src/ua/data_types/create_monitored_items_request.rs
+++ b/src/ua/data_types/create_monitored_items_request.rs
@@ -4,7 +4,7 @@ crate::data_type!(CreateMonitoredItemsRequest);
 
 impl CreateMonitoredItemsRequest {
     #[must_use]
-    pub fn with_subscription_id(mut self, subscription_id: ua::SubscriptionId) -> Self {
+    pub const fn with_subscription_id(mut self, subscription_id: ua::SubscriptionId) -> Self {
         self.0.subscriptionId = subscription_id.as_u32();
         self
     }

--- a/src/ua/data_types/delete_monitored_items_request.rs
+++ b/src/ua/data_types/delete_monitored_items_request.rs
@@ -4,7 +4,7 @@ crate::data_type!(DeleteMonitoredItemsRequest);
 
 impl DeleteMonitoredItemsRequest {
     #[must_use]
-    pub fn with_subscription_id(mut self, subscription_id: ua::SubscriptionId) -> Self {
+    pub const fn with_subscription_id(mut self, subscription_id: ua::SubscriptionId) -> Self {
         self.0.subscriptionId = subscription_id.as_u32();
         self
     }

--- a/src/ua/data_types/node_attributes/method_attributes.rs
+++ b/src/ua/data_types/node_attributes/method_attributes.rs
@@ -1,12 +1,12 @@
 impl super::MethodAttributes {
     #[must_use]
-    pub fn with_executable(mut self, executable: bool) -> Self {
+    pub const fn with_executable(mut self, executable: bool) -> Self {
         self.0.executable = executable;
         self
     }
 
     #[must_use]
-    pub fn with_user_executable(mut self, user_executable: bool) -> Self {
+    pub const fn with_user_executable(mut self, user_executable: bool) -> Self {
         self.0.userExecutable = user_executable;
         self
     }

--- a/src/ua/data_types/node_attributes/variable_attributes.rs
+++ b/src/ua/data_types/node_attributes/variable_attributes.rs
@@ -9,14 +9,14 @@ impl super::VariableAttributes {
     }
 
     #[must_use]
-    pub fn with_value_rank(mut self, rank: i32) -> Self {
+    pub const fn with_value_rank(mut self, rank: i32) -> Self {
         self.0.valueRank = rank;
         self.0.specifiedAttributes |= ua::SpecifiedAttributes::VALUERANK.as_u32();
         self
     }
 
     #[must_use]
-    pub fn with_access_level(mut self, access_level: &ua::AccessLevel) -> Self {
+    pub const fn with_access_level(mut self, access_level: &ua::AccessLevel) -> Self {
         self.0.accessLevel = access_level.as_u8();
         self.0.specifiedAttributes |= ua::SpecifiedAttributes::ACCESSLEVEL.as_u32();
         self

--- a/src/ua/data_types/relative_path_element.rs
+++ b/src/ua/data_types/relative_path_element.rs
@@ -10,13 +10,13 @@ impl RelativePathElement {
     }
 
     #[must_use]
-    pub fn with_is_inverse(mut self, is_inverse: bool) -> Self {
+    pub const fn with_is_inverse(mut self, is_inverse: bool) -> Self {
         self.0.isInverse = is_inverse;
         self
     }
 
     #[must_use]
-    pub fn with_include_subtypes(mut self, include_subtypes: bool) -> Self {
+    pub const fn with_include_subtypes(mut self, include_subtypes: bool) -> Self {
         self.0.includeSubtypes = include_subtypes;
         self
     }


### PR DESCRIPTION
## Description

This fixes Clippy hints that were introduced with the upgrade to [Rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html).