### PR TITLE
Upgrade to open62541 version 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to open62541 version [1.4.7](https://github.com/open62541/open62541/releases/tag/v1.4.7).
+
 ## [0.6.3] - 2024-10-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,13 +513,14 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf501aa3e05d2822660740af47d88ff64b2f9e107b90ec7eb4642fc3ae352c2d"
+checksum = "d849eadecda6a8f046eae6ef793e6dbb322e6f24f77c608a5b5b1f5829b2e3dc"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
+ "version_check",
 ]
 
 [[package]]
@@ -818,6 +819,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.3"
+open62541-sys = "0.4.4"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest released version [1.4.7](https://github.com/open62541/open62541/releases/tag/v1.4.7) of [open62541](https://github.com/open62541/open62541).