### PR TITLE
Use consistent spelling of cancelled and cancelling

### DIFF
--- a/.codespelldictionary
+++ b/.codespelldictionary
@@ -1,0 +1,2 @@
+canceled->cancelled
+canceling->cancelling

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+dictionary = .codespelldictionary,-
+ignore-words = .codespellignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: [--ignore-words=.codespellignore]
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.29.4
     hooks:

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -94,7 +94,7 @@ fn main() -> anyhow::Result<()> {
 
     cancel_tx.send(()).expect("server task should be running");
 
-    // Wait for simulation task to shut down after canceling.
+    // Wait for simulation task to shut down after cancelling.
     if let Err(err) = server_task_handle
         .join()
         .expect("server task should not panic")

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -23,8 +23,8 @@ use crate::{
 /// Timeout for `UA_Client_run_iterate()`.
 ///
 /// This is the maximum amount of time that `UA_Client_run_iterate()` will block for. It is relevant
-/// primarily when canceling the background task, i.e. when we need to interrupt the loop and cancel
-/// before the next invocation of `UA_Client_run_iterate()`.
+/// primarily when cancelling the background task, i.e. when we interrupt the loop and cancel before
+/// the next invocation of `UA_Client_run_iterate()`.
 ///
 /// Since this is also the timeout we must block for when dropping the client without `disconnect()`
 /// first, the value should not be too large. On the other hand, it should not be too small to avoid
@@ -104,7 +104,7 @@ impl AsyncClient {
         };
 
         if cancel {
-            log::info!("Canceling background task");
+            log::info!("Cancelling background task");
             self.background_cancelled.store(true, Ordering::Relaxed);
         }
 

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -184,7 +184,7 @@ async fn create_monitored_items(
     let callback = |result: std::result::Result<ua::CreateMonitoredItemsResponse, _>| {
         // We always send a result back via `tx` (in fact, `rx.await` below expects this). We do not
         // care if that succeeds though: the receiver might already have gone out of scope (when its
-        // future has been canceled) and we must not panic in FFI callbacks.
+        // future has been cancelled) and we must not panic in FFI callbacks.
         let _unused = tx.send(result.map_err(Error::new));
     };
 

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -97,7 +97,7 @@ async fn create_subscription(
     let callback = |result: std::result::Result<ua::CreateSubscriptionResponse, _>| {
         // We always send a result back via `tx` (in fact, `rx.await` below expects this). We do not
         // care if that succeeds though: the receiver might already have gone out of scope (when its
-        // future has been canceled) and we must not panic in FFI callbacks.
+        // future has been cancelled) and we must not panic in FFI callbacks.
         let _unused = tx.send(result.map_err(Error::new));
     };
 


### PR DESCRIPTION
## Description

This removes some inconsistencies of internal names for cancelled stuff and cancelling. We use the British spelling with two L instead of the American spelling with one L to match [tokio](https://crates.io/crates/tokio)'s [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html).

The [codespell](https://github.com/codespell-project/codespell) pre-commit hook is used to make sure that future edits stay consistent and use the spelling with two L.