### PR TITLE
Remove tokio dependency from cancellable server example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,6 @@ path = "examples/server_builder.rs"
 [[example]]
 name = "server_cancellable"
 path = "examples/server_cancellable.rs"
-required-features = ["tokio"]
 
 [[example]]
 name = "server_data_source"

--- a/examples/server_cancellable.rs
+++ b/examples/server_cancellable.rs
@@ -9,7 +9,7 @@ use std::{
 
 use open62541::Server;
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     env_logger::init();
 
     let (_, runner) = Server::new();
@@ -42,6 +42,4 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("Exiting");
-
-    Ok(())
 }


### PR DESCRIPTION
## Description

This is a follow-up to #169 and removes the dependency on [tokio](https://crates.io/crates/tokio) for the example showcasing the cancellable server.