### PR TITLE
Fix possible memory-leak when access control cannot be applied

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -39,7 +39,7 @@ use crate::Userdata;
 /// assert_eq!(cell.get(), 123);
 /// ```
 #[derive(Debug)]
-pub struct CallbackOnce<T>(PhantomData<T>);
+pub struct CallbackOnce<T: 'static>(PhantomData<T>);
 
 // TODO: Use inherent associated type to define this directly on `CallbackOnce`. At the moment, this
 // is not possible yet.
@@ -114,7 +114,7 @@ impl<T> CallbackOnce<T> {
 /// assert_eq!(block_on(rx.recv()), None);
 /// ```
 #[derive(Debug)]
-pub struct CallbackStream<T>(PhantomData<T>);
+pub struct CallbackStream<T: 'static>(PhantomData<T>);
 
 // TODO: Use inherent associated type to define this directly on `CallbackOnce`. At the moment, this
 // is not possible yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub use self::{
         MethodNode, Node, ObjectNode, Server, ServerBuilder, ServerRunner, VariableNode,
     },
     traits::{Attribute, Attributes},
-    userdata::Userdata,
+    userdata::{Userdata, UserdataSentinel},
     value::{ScalarValue, ValueType, VariantValue},
 };
 pub(crate) use self::{

--- a/src/server/access_control.rs
+++ b/src/server/access_control.rs
@@ -201,7 +201,10 @@ where
             }
         }];
 
-        let login_callback = Userdata::<F>::prepare(login_callback);
+        // Create sentinel that owns the callback closure. This is either returned to the caller (in
+        // case everything works as expected) or cleaned up when exiting with `?` below (in case the
+        // function call is not successful).
+        let login_callback_sentinel = Userdata::<F>::prepare_sentinel(login_callback);
 
         let status_code = ua::StatusCode::new(unsafe {
             UA_AccessControl_defaultWithLoginCallback(
@@ -215,20 +218,15 @@ where
                 username_password_login.len(),
                 username_password_login.as_ptr(),
                 Some(login_callback_c::<F>),
-                login_callback,
+                login_callback_sentinel.as_ptr(),
             )
         });
-        // Create sentinel right after calling `UA_AccessControl_defaultWithLoginCallback()` to make
-        // sure that we clean up when exiting the function through `?` below. In all other cases, we
-        // return the sentinel to the caller as documented.
-        //
-        // SAFETY: We do not call `consume()` and only create a single sentinel.
-        let sentinel = unsafe { Userdata::<F>::sentinel(login_callback) };
         Error::verify_good(&status_code)?;
 
-        // Compile-time assertion to make sure that the strings were still alive at this point.
+        // Compile-time assertion to make sure that the strings were still alive at this point. This
+        // includes the branch above when exiting early with `?`.
         drop((username, password));
 
-        Ok(sentinel)
+        Ok(login_callback_sentinel)
     }
 }

--- a/src/server/access_control.rs
+++ b/src/server/access_control.rs
@@ -158,7 +158,7 @@ where
             login_context: *mut c_void,
         ) -> UA_StatusCode
         where
-            F: Fn(&ua::String, &ua::ByteString) -> ua::StatusCode,
+            F: Fn(&ua::String, &ua::ByteString) -> ua::StatusCode + 'static,
         {
             let Some(user_name) = (unsafe { user_name.as_ref() }) else {
                 return UA_STATUSCODE_BADINTERNALERROR;

--- a/src/server/access_control.rs
+++ b/src/server/access_control.rs
@@ -218,13 +218,16 @@ where
                 login_callback,
             )
         });
+        // Create sentinel right after calling `UA_AccessControl_defaultWithLoginCallback()` to make
+        // sure that we clean up when exiting the function through `?` below. In all other cases, we
+        // return the sentinel to the caller as documented.
+        //
+        // SAFETY: We do not call `consume()` and only create a single sentinel.
+        let sentinel = unsafe { Userdata::<F>::sentinel(login_callback) };
         Error::verify_good(&status_code)?;
 
         // Compile-time assertion to make sure that the strings were still alive at this point.
         drop((username, password));
-
-        // SAFETY: We do not call `consume()` and only create a single sentinel.
-        let sentinel = unsafe { Userdata::<F>::sentinel(login_callback) };
 
         Ok(sentinel)
     }

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -44,6 +44,8 @@ use std::{ffi::c_void, marker::PhantomData};
 /// // Got user data. `raw_data` is no longer valid.
 /// assert_eq!(userdata, 123);
 /// ```
+// We allow only types with static lifetime (i.e. without references that would not be valid for the
+// rest of the program) to allow leaking their values safely onto the heap to reclaim them later.
 #[derive(Debug)]
 pub struct Userdata<T: 'static>(PhantomData<T>);
 

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -84,7 +84,8 @@ impl<T> Userdata<T> {
     /// It must not have been given to [`consume()`] yet.
     ///
     /// The lifetime of the returned reference is not allowed to extend past the next call to either
-    /// [`peek_at()`] or [`consume()`] and must not outlive the lifetime of `T` itself.
+    /// [`peek_at()`] or [`consume()`] and must not outlive the lifetime of `T` itself. (In case the
+    /// user data has been wrapped into a [`UserdataSentinel`], the sentinel must still be alive.)
     ///
     /// [`prepare()`]: Self::prepare
     /// [`peek_at()`]: Self::peek_at
@@ -103,7 +104,8 @@ impl<T> Userdata<T> {
     /// # Safety
     ///
     /// The given pointer must have been returned from [`prepare()`], using the same value type `T`.
-    /// It must not have been given to [`consume()`] yet.
+    /// It must not have been given to [`consume()`] yet, nor wrapped in a [`UserdataSentinel`] (the
+    /// user data is consumed automatically when the sentinel is being dropped).
     ///
     /// [`prepare()`]: Self::prepare
     /// [`consume()`]: Self::consume
@@ -114,7 +116,7 @@ impl<T> Userdata<T> {
         // Reconstruct heap-allocated `userdata` back into its `Box`.
         let userdata = unsafe { Box::from_raw(ptr) };
         // TODO: Prefer `Box::into_inner()` when it becomes stable.
-        // https://github.com/rust-lang/rust/issues/80437
+        // <https://github.com/rust-lang/rust/issues/80437>
         *userdata
     }
 }

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -136,7 +136,8 @@ impl<T> UserdataSentinel<T> {
     ///
     /// The sentinel remains the owner of the data. Care must be taken to not access the data in any
     /// way past the lifetime of the sentinel.
-    pub unsafe fn as_ptr(&self) -> *mut c_void {
+    #[must_use]
+    pub const unsafe fn as_ptr(&self) -> *mut c_void {
         self.0
     }
 }

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -45,7 +45,7 @@ use std::{ffi::c_void, marker::PhantomData};
 /// assert_eq!(userdata, 123);
 /// ```
 #[derive(Debug)]
-pub struct Userdata<T>(PhantomData<T>);
+pub struct Userdata<T: 'static>(PhantomData<T>);
 
 impl<T> Userdata<T> {
     /// Wraps user data.
@@ -125,7 +125,7 @@ impl<T> Userdata<T> {
 ///
 /// This consumes the user data when dropped.
 #[derive(Debug)]
-pub struct UserdataSentinel<T>(*mut c_void, PhantomData<T>);
+pub struct UserdataSentinel<T: 'static>(*mut c_void, PhantomData<T>);
 
 impl<T> UserdataSentinel<T> {
     /// Gets underlying pointer from sentinel.


### PR DESCRIPTION
## Description

This is a follow-up to #176 and removes the chance of a memory leak when access control cannot be applied.