### PR TITLE
Upgrade to open62541 version 1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgrade to open62541 version [1.4.8](https://github.com/open62541/open62541/releases/tag/v1.4.8).
+
 ## [0.6.4] - 2024-11-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23a0167943e2e162e0f9e8497c8cdbc263280dd91ccbaf91cac25edeb153801"
+checksum = "dde198550d8fdac6a4ed820e7a09c934ad799784a23e5cec882e954c9f5d3aca"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.6"
+open62541-sys = "0.4.7"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest released version [1.4.8](https://github.com/open62541/open62541/releases/tag/v1.4.8) of [open62541](https://github.com/open62541/open62541).