### PR TITLE
Add missing Send/Sync implementations for `Array` and `KeyValueMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Implement `Send` and `Sync` for `ua::Array` and `ua::KeyValueMap`.
+
 ## [0.6.5] - 2024-12-04
 
 ### Added
@@ -317,6 +323,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First public release.
 
+[Unreleased]: https://github.com/HMIProject/open62541/compare/v0.6.5...HEAD
 [0.6.5]: https://github.com/HMIProject/open62541/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/HMIProject/open62541/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/HMIProject/open62541/compare/v0.6.2...v0.6.3


### PR DESCRIPTION
## Description

This adds `Send` and `Sync` implementations for `ua::Array` and `ua::KeyValueMap` which can be sent and accessed across threads, just like the values they contain.