### PR TITLE
Implement memory zeroization before dropping private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Zeroize memory held by `PrivateKey` when dropped.
+
 ## [0.7.0] - 2024-12-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "time",
  "tokio",
  "x509-certificate",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1.35.1", optional = true, features = [
   "time",
 ] }
 x509-certificate = { version = "0.24.0", optional = true }
+zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.79"
@@ -47,7 +48,7 @@ tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["serde", "time", "tokio"]
-mbedtls = ["open62541-sys/mbedtls"]
+mbedtls = ["dep:zeroize", "open62541-sys/mbedtls"]
 serde = ["dep:serde", "dep:serde_json", "time?/formatting", "time?/serde"]
 time = ["dep:time"]
 tokio = ["dep:tokio"]


### PR DESCRIPTION
## Description

This makes sure that we [zeroize](https://en.wikipedia.org/wiki/Zeroisation) the memory held by `PrivateKey` to not leak the data therein when we no longer own that memory region.