### PR TITLE
Work around failing CI workflow on `cargo install`

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -66,8 +66,10 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install Cargo helpers
+        # Fall back to installing with locked dependencies when installed rustc
+        # is too old.
         run: >-
-          cargo install cargo-hack
+          cargo install cargo-hack || cargo install --locked cargo-hack
 
       # Check out the repository before the remaining steps that depend on it.
       # All preceding steps are independent of the repository contents.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,8 +90,10 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install Cargo helpers
+        # Fall back to installing with locked dependencies when installed rustc
+        # is too old.
         run: >-
-          cargo install cargo-hack
+          cargo install cargo-hack || cargo install --locked cargo-hack
 
       # Check out the repository before the remaining steps that depend on it.
       # All preceding steps are independent of the repository contents.


### PR DESCRIPTION
## Description

This PR adds a workaround for the invocation of `cargo install cargo-hack` in case it it fails when the CI runner image does not provide the necessary Rust version.

See https://github.com/HMIProject/open62541/actions/runs/12414513710/job/34658803434?pr=188.