### PR TITLE
Write data value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ required-features = ["mbedtls"]
 
 [[example]]
 name = "server"
+required-features = ["time"]
 
 [[example]]
 name = "server_access_control"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -10,6 +10,7 @@ use open62541_sys::{
     UA_NS0ID_BASEDATAVARIABLETYPE, UA_NS0ID_FOLDERTYPE, UA_NS0ID_OBJECTSFOLDER, UA_NS0ID_ORGANIZES,
     UA_NS0ID_STRING,
 };
+use time::macros::datetime;
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -42,6 +43,27 @@ fn main() -> anyhow::Result<()> {
     server.write_value(
         &variable_node_id,
         &ua::Variant::scalar(ua::String::new("foobar")?),
+    )?;
+
+    let data_value_variable_node = VariableNode {
+        requested_new_node_id: Some(ua::NodeId::string(1, "the.answer.data.value")),
+        parent_node_id: object_node_id.clone(),
+        reference_type_id: ua::NodeId::ns0(UA_NS0ID_ORGANIZES),
+        browse_name: ua::QualifiedName::new(1, "the answer.data.value"),
+        type_definition: ua::NodeId::ns0(UA_NS0ID_BASEDATAVARIABLETYPE),
+        attributes: ua::VariableAttributes::default()
+            .with_data_type(&ua::NodeId::ns0(UA_NS0ID_STRING)),
+    };
+    let data_value_variable_node_id = server.add_variable_node(data_value_variable_node)?;
+
+    //let ua_datetime = ua::DateTime::init();
+
+    let ua_datetime: ua::DateTime = datetime!(2024-02-09 12:34:56 UTC).try_into().unwrap();
+
+    server.write_data_value(
+        &data_value_variable_node_id,
+        &ua::DataValue::new(ua::Variant::scalar(ua::String::new("foobar")?))
+            .with_source_timestamp(&ua_datetime),
     )?;
 
     read_attribute(&server, &variable_node_id, ua::AttributeId::NODEID_T)?;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -54,10 +54,8 @@ fn main() -> anyhow::Result<()> {
         attributes: ua::VariableAttributes::default()
             .with_data_type(&ua::NodeId::ns0(UA_NS0ID_STRING)),
     };
+    
     let data_value_variable_node_id = server.add_variable_node(data_value_variable_node)?;
-
-    //let ua_datetime = ua::DateTime::init();
-
     let ua_datetime: ua::DateTime = datetime!(2024-02-09 12:34:56 UTC).try_into().unwrap();
 
     server.write_data_value(

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,8 +19,9 @@ use open62541_sys::{
     UA_Server_browseSimplifiedBrowsePath, UA_Server_createEvent, UA_Server_deleteNode,
     UA_Server_deleteReference, UA_Server_getNamespaceByIndex, UA_Server_getNamespaceByName,
     UA_Server_read, UA_Server_readObjectProperty, UA_Server_runUntilInterrupt,
-    UA_Server_translateBrowsePathToNodeIds, UA_Server_triggerEvent, UA_Server_writeObjectProperty,
-    __UA_Server_addNode, __UA_Server_write, UA_STATUSCODE_BADNOTFOUND,
+    UA_Server_translateBrowsePathToNodeIds, UA_Server_triggerEvent, UA_Server_writeDataValue,
+    UA_Server_writeObjectProperty, __UA_Server_addNode, __UA_Server_write,
+    UA_STATUSCODE_BADNOTFOUND,
 };
 
 use crate::{
@@ -1301,6 +1302,23 @@ impl Server {
                 ua::AttributeId::VALUE.into_raw(),
                 ua::Variant::data_type(),
                 value.as_ptr().cast::<c_void>(),
+            )
+        });
+        Error::verify_good(&status_code)
+    }
+
+    /// Writes a `DataValue` to a node.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the node does not exist or its value attribute cannot be written.
+    pub fn write_data_value(&self, node_id: &ua::NodeId, data_value: &ua::DataValue) -> Result<()> {
+        let status_code = ua::StatusCode::new(unsafe {
+            UA_Server_writeDataValue(
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                self.0.as_ptr().cast_mut(),
+                DataType::to_raw_copy(node_id),
+                DataType::to_raw_copy(data_value),
             )
         });
         Error::verify_good(&status_code)


### PR DESCRIPTION
## Description

Allow support for writing ua::DataValue to a server.

## Testing details

Tested and confirmed OPC-UA Server example writes to a variable node with a ua::DataValue in example code.
Viewed data with a separate OPC-UA client.

Confirmed pre-commit output.

```
akoerner@xyz open62541 % just pre-commit
pre-commit run --all-files
check for case conflicts.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check toml...............................................................Passed
check xml............................................(no files to check)Skipped
check yaml...............................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
fix utf-8 byte order marker..............................................Passed
forbid new submodules................................(no files to check)Skipped
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
markdownlint-cli2........................................................Passed
codespell................................................................Passed
Validate GitHub Actions..............................(no files to check)Skipped
Validate GitHub Workflows................................................Passed
taplo-format.............................................................Passed
taplo-lint...............................................................Passed
prettier.................................................................Passed
fmt......................................................................Passed
clippy --all-features....................................................Passed
clippy --no-default-features.............................................Passed
cargo-doc................................................................Passed
```