### PR TITLE
Allow setting subscription and monitored item parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add method `Server::write_data_value()` to allow setting variable value with timestamps (#190).
+- Add `SubscriptionBuilder` and `MonitoredItemBuilder` to create subscription and monitored items
+  with additional control over request options.
 
 ### Changed
 

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -84,15 +84,14 @@ async fn subscribe_node_with_options(client: &AsyncClient) -> anyhow::Result<()>
     let subscription = SubscriptionBuilder::default()
         .requested_publishing_interval(Duration::from_millis(100))
         .max_notifications_per_publish(0)
-        .create(&client)
+        .create(client)
         .await
         .context("create subscription with options")?;
 
     let node_id = ua::NodeId::numeric(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
 
-    let monitored_items = MonitoredItemBuilder::default()
+    let monitored_items = MonitoredItemBuilder::new([node_id])
         .sampling_interval(Some(Duration::from_millis(100)))
-        .node_ids(&[node_id])
         .create(&subscription)
         .await
         .context("monitor items")?;

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -19,6 +19,30 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Connected successfully");
 
+    subscribe_node(&client).await?;
+
+    time::sleep(Duration::from_millis(500)).await;
+
+    read_nodes(&client).await?;
+
+    time::sleep(Duration::from_millis(500)).await;
+
+    browse_node(&client).await?;
+
+    time::sleep(Duration::from_millis(500)).await;
+
+    println!("Disconnecting client");
+
+    client.disconnect().await;
+
+    time::sleep(Duration::from_millis(500)).await;
+
+    println!("Exiting");
+
+    Ok(())
+}
+
+async fn subscribe_node(client: &AsyncClient) -> anyhow::Result<()> {
     println!("Creating subscription");
 
     let subscription = client
@@ -47,8 +71,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Subscription dropped");
 
-    time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
 
+async fn read_nodes(client: &AsyncClient) -> anyhow::Result<()> {
     println!("Reading some items");
 
     let builddate = ua::NodeId::numeric(0, UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_BUILDDATE);
@@ -69,8 +95,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("{results:?}");
 
-    time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
 
+async fn browse_node(client: &AsyncClient) -> anyhow::Result<()> {
     println!("Browsing node");
 
     let (references, _) = client
@@ -82,16 +110,6 @@ async fn main() -> anyhow::Result<()> {
         .context("browse node")?;
 
     println!("{references:?}");
-
-    time::sleep(Duration::from_millis(500)).await;
-
-    println!("Disconnecting client");
-
-    client.disconnect().await;
-
-    time::sleep(Duration::from_millis(500)).await;
-
-    println!("Exiting");
 
     Ok(())
 }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -469,7 +469,9 @@ impl AsyncClient {
     ///
     /// This fails when the client is not connected.
     pub async fn create_subscription(&self) -> Result<AsyncSubscription> {
-        SubscriptionBuilder::default().create(self).await
+        let (_, subscription) = SubscriptionBuilder::default().create(self).await?;
+
+        Ok(subscription)
     }
 
     pub(crate) const fn client(&self) -> &Arc<ua::Client> {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -16,8 +16,8 @@ use open62541_sys::{
 use tokio::{sync::oneshot, task, time::Instant};
 
 use crate::{
-    ua, AsyncSubscription, Attribute, BrowseResult, CallbackOnce, DataType, DataValue, Error,
-    Result, ServiceRequest, ServiceResponse,
+    ua, AsyncSubscription, Attribute, BrowseResult, CallbackOnce, CreateSubscriptionOptions,
+    DataType, DataValue, Error, Result, ServiceRequest, ServiceResponse,
 };
 
 /// Timeout for `UA_Client_run_iterate()`.
@@ -469,7 +469,22 @@ impl AsyncClient {
     ///
     /// This fails when the client is not connected.
     pub async fn create_subscription(&self) -> Result<AsyncSubscription> {
-        AsyncSubscription::new(&self.client).await
+        self.create_subscription_with_options(CreateSubscriptionOptions::default())
+            .await
+    }
+
+    /// Creates new [subscription](AsyncSubscription) with options.
+    ///
+    /// This allows overriding the parameters used in the request.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the client is not connected.
+    pub async fn create_subscription_with_options(
+        &self,
+        options: CreateSubscriptionOptions,
+    ) -> Result<AsyncSubscription> {
+        AsyncSubscription::new(&self.client, options).await
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -16,8 +16,8 @@ use open62541_sys::{
 use tokio::{sync::oneshot, task, time::Instant};
 
 use crate::{
-    ua, AsyncSubscription, Attribute, BrowseResult, CallbackOnce, CreateSubscriptionOptions,
-    DataType, DataValue, Error, Result, ServiceRequest, ServiceResponse,
+    ua, AsyncSubscription, Attribute, BrowseResult, CallbackOnce, DataType, DataValue, Error,
+    Result, ServiceRequest, ServiceResponse, SubscriptionBuilder,
 };
 
 /// Timeout for `UA_Client_run_iterate()`.
@@ -469,22 +469,11 @@ impl AsyncClient {
     ///
     /// This fails when the client is not connected.
     pub async fn create_subscription(&self) -> Result<AsyncSubscription> {
-        self.create_subscription_with_options(CreateSubscriptionOptions::default())
-            .await
+        SubscriptionBuilder::default().create(self).await
     }
 
-    /// Creates new [subscription](AsyncSubscription) with options.
-    ///
-    /// This allows overriding the parameters used in the request.
-    ///
-    /// # Errors
-    ///
-    /// This fails when the client is not connected.
-    pub async fn create_subscription_with_options(
-        &self,
-        options: CreateSubscriptionOptions,
-    ) -> Result<AsyncSubscription> {
-        AsyncSubscription::new(&self.client, options).await
+    pub(crate) const fn client(&self) -> &Arc<ua::Client> {
+        &self.client
     }
 }
 

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -331,8 +331,8 @@ async fn create_monitored_items(
         // TODO: Think about appropriate buffer size or let the caller decide.
         let (st_tx, st_rx) = mpsc::channel::<ua::DataValue>(MONITORED_ITEM_BUFFER_SIZE);
 
-        // `open62541` requires one set of notification/delete callback and context per monitor item
-        // in the request.
+        // `open62541` requires one set of notification/delete callback and context per monitored
+        // item in the request.
         let notification_callback: UA_Client_DataChangeNotificationCallback =
             Some(notification_callback_c);
         let delete_callback: UA_Client_DeleteMonitoredItemCallback = Some(delete_callback_c);

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 
 use crate::{ua, AsyncSubscription, CallbackOnce, CallbackStream, DataType as _, Error, Result};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MonitoredItemBuilder {
     node_ids: Vec<ua::NodeId>,
     monitoring_mode: Option<ua::MonitoringMode>,
@@ -30,11 +30,14 @@ pub struct MonitoredItemBuilder {
 }
 
 impl MonitoredItemBuilder {
-    /// Sets monitored node IDs.
-    #[must_use]
-    pub fn node_ids(mut self, node_id: &[ua::NodeId]) -> Self {
-        self.node_ids = node_id.to_vec();
-        self
+    pub fn new(node_ids: impl IntoIterator<Item = ua::NodeId>) -> Self {
+        Self {
+            node_ids: node_ids.into_iter().collect(),
+            monitoring_mode: None,
+            sampling_interval: None,
+            queue_size: None,
+            discard_oldest: None,
+        }
     }
 
     /// Sets monitoring mode.

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -29,6 +29,7 @@ pub struct MonitoredItemBuilder {
     discard_oldest: Option<bool>,
 }
 
+// Note: The default values in the docs below come from `UA_MonitoredItemCreateRequest_default()`.
 impl MonitoredItemBuilder {
     pub fn new(node_ids: impl IntoIterator<Item = ua::NodeId>) -> Self {
         Self {
@@ -42,6 +43,8 @@ impl MonitoredItemBuilder {
 
     /// Sets monitoring mode.
     ///
+    /// Default value is [`ua::MonitoringMode::REPORTING`].
+    ///
     /// See [`ua::MonitoredItemCreateRequest::with_monitoring_mode()`].
     #[must_use]
     pub fn monitoring_mode(mut self, monitoring_mode: ua::MonitoringMode) -> Self {
@@ -50,6 +53,8 @@ impl MonitoredItemBuilder {
     }
 
     /// Sets sampling interval.
+    ///
+    /// Default value is 250.0 [ms].
     ///
     /// See [`ua::MonitoringParameters::with_sampling_interval()`].
     #[must_use]
@@ -60,6 +65,8 @@ impl MonitoredItemBuilder {
 
     /// Set requested size of the monitored item queue.
     ///
+    /// Default value is 1.
+    ///
     /// See [`ua::MonitoringParameters::with_queue_size()`].
     #[must_use]
     pub const fn queue_size(mut self, queue_size: u32) -> Self {
@@ -68,6 +75,8 @@ impl MonitoredItemBuilder {
     }
 
     /// Set discard policy.
+    ///
+    /// Default value is `true`.
     ///
     /// See [`ua::MonitoringParameters::with_discard_oldest()`].
     #[must_use]

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -54,7 +54,7 @@ impl MonitoredItemBuilder {
 
     /// Sets sampling interval.
     ///
-    /// Default value is 250.0 [ms].
+    /// Default value is 250.0 ms.
     ///
     /// See [`ua::MonitoringParameters::with_sampling_interval()`].
     #[must_use]

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -158,8 +158,7 @@ impl AsyncSubscription {
     ///
     /// This fails when the node does not exist.
     pub async fn create_monitored_item(&self, node_id: &ua::NodeId) -> Result<AsyncMonitoredItem> {
-        let monitored_items = MonitoredItemBuilder::default()
-            .node_ids(&[node_id.clone()])
+        let monitored_items = MonitoredItemBuilder::new([node_id.clone()])
             .create(self)
             .await?;
 

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::c_void,
+    num::NonZeroU32,
     ptr,
     sync::{Arc, Weak},
     time::Duration,
@@ -18,28 +19,36 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub struct SubscriptionBuilder {
-    requested_publishing_interval: Option<Duration>,
+    #[allow(clippy::option_option)]
+    requested_publishing_interval: Option<Option<Duration>>,
     requested_lifetime_count: Option<u32>,
-    requested_max_keep_alive_count: Option<u32>,
-    max_notifications_per_publish: Option<u32>,
+    #[allow(clippy::option_option)]
+    requested_max_keep_alive_count: Option<Option<NonZeroU32>>,
+    #[allow(clippy::option_option)]
+    max_notifications_per_publish: Option<Option<NonZeroU32>>,
     publishing_enabled: Option<bool>,
     priority: Option<u8>,
 }
 
+// Note: The default values in the docs below come from `UA_CreateSubscriptionRequest_default()`.
 impl SubscriptionBuilder {
     /// Sets requested publishing interval.
+    ///
+    /// Default value is 500.0 [ms].
     ///
     /// See [`ua::CreateSubscriptionRequest::with_requested_publishing_interval()`].
     #[must_use]
     pub const fn requested_publishing_interval(
         mut self,
-        requested_publishing_interval: Duration,
+        requested_publishing_interval: Option<Duration>,
     ) -> Self {
         self.requested_publishing_interval = Some(requested_publishing_interval);
         self
     }
 
     /// Sets requested lifetime count.
+    ///
+    /// Default value is 10000.
     ///
     /// See [`ua::CreateSubscriptionRequest::with_requested_lifetime_count()`].
     #[must_use]
@@ -50,11 +59,13 @@ impl SubscriptionBuilder {
 
     /// Sets requested maximum keep-alive count.
     ///
+    /// Default value is 10.
+    ///
     /// See [`ua::CreateSubscriptionRequest::with_requested_max_keep_alive_count()`].
     #[must_use]
     pub const fn requested_max_keep_alive_count(
         mut self,
-        requested_max_keep_alive_count: u32,
+        requested_max_keep_alive_count: Option<NonZeroU32>,
     ) -> Self {
         self.requested_max_keep_alive_count = Some(requested_max_keep_alive_count);
         self
@@ -63,17 +74,21 @@ impl SubscriptionBuilder {
     /// Sets maximum number of notifications that the client wishes to receive in a single publish
     /// response.
     ///
+    /// Default value is `None` (unlimited).
+    ///
     /// See [`ua::CreateSubscriptionRequest::with_max_notifications_per_publish()`].
     #[must_use]
     pub const fn max_notifications_per_publish(
         mut self,
-        max_notifications_per_publish: u32,
+        max_notifications_per_publish: Option<NonZeroU32>,
     ) -> Self {
         self.max_notifications_per_publish = Some(max_notifications_per_publish);
         self
     }
 
     /// Enables or disables publishing.
+    ///
+    /// Default value is `true`.
     ///
     /// See [`ua::CreateSubscriptionRequest::with_publishing_enabled()`].
     #[must_use]
@@ -83,6 +98,8 @@ impl SubscriptionBuilder {
     }
 
     /// Sets relative priority of the subscription.
+    ///
+    /// Default value is 0.
     ///
     /// See [`ua::CreateSubscriptionRequest::with_priority()`].
     #[must_use]

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -34,7 +34,7 @@ pub struct SubscriptionBuilder {
 impl SubscriptionBuilder {
     /// Sets requested publishing interval.
     ///
-    /// Default value is 500.0 [ms].
+    /// Default value is 500.0 ms.
     ///
     /// See [`ua::CreateSubscriptionRequest::with_requested_publishing_interval()`].
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,8 @@ pub use self::ssl::{create_certificate, Certificate, PrivateKey};
 #[cfg(feature = "tokio")]
 pub use self::{
     async_client::AsyncClient,
-    async_monitored_item::AsyncMonitoredItem,
-    async_subscription::AsyncSubscription,
+    async_monitored_item::{AsyncMonitoredItem, CreateMonitoredItemOptions},
+    async_subscription::{AsyncSubscription, CreateSubscriptionOptions},
     callback::{CallbackOnce, CallbackStream},
 };
 pub use self::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,8 @@ pub use self::ssl::{create_certificate, Certificate, PrivateKey};
 #[cfg(feature = "tokio")]
 pub use self::{
     async_client::AsyncClient,
-    async_monitored_item::{AsyncMonitoredItem, CreateMonitoredItemOptions},
-    async_subscription::{AsyncSubscription, CreateSubscriptionOptions},
+    async_monitored_item::{AsyncMonitoredItem, MonitoredItemBuilder},
+    async_subscription::{AsyncSubscription, SubscriptionBuilder},
     callback::{CallbackOnce, CallbackStream},
 };
 pub use self::{

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -175,6 +175,7 @@ impl<T: DataType> Array<T> {
     ///
     /// Ownership is transferred. There must not be any aliased references to the array elements, as
     /// they will be owned and freed when the returned value is dropped.
+    #[allow(dead_code)] // --no-default-features
     pub(crate) unsafe fn move_from_raw_parts(
         size: &mut usize,
         ptr: &mut *mut T::Inner,

--- a/src/ua/array.rs
+++ b/src/ua/array.rs
@@ -167,6 +167,49 @@ impl<T: DataType> Array<T> {
         Some(Self::from_slice(slice))
     }
 
+    /// Creates new array by moving out of raw parts.
+    ///
+    /// When an array is returned, this leaves behind an empty array in the original position.
+    ///
+    /// # Safety
+    ///
+    /// Ownership is transferred. There must not be any aliased references to the array elements, as
+    /// they will be owned and freed when the returned value is dropped.
+    pub(crate) unsafe fn move_from_raw_parts(
+        size: &mut usize,
+        ptr: &mut *mut T::Inner,
+    ) -> Option<Self> {
+        if *size == 0 {
+            if ptr.is_null() {
+                // This indicates an undefined array of unknown length. We do not handle this in the
+                // type but return `None` instead.
+                return None;
+            }
+            // Otherwise, we expect the sentinel value to indicate an empty array of length 0. This,
+            // we do handle and may return `Some`.
+            debug_assert_eq!(ptr.cast::<c_void>().cast_const(), unsafe {
+                UA_EMPTY_ARRAY_SENTINEL
+            });
+            return Some(Self(State::Empty));
+        }
+
+        // We require a proper pointer for safe operation (even when we do not access the pointed-to
+        // memory region at all, cf. documentation of `from_raw_parts()`).
+        debug_assert!(!ptr.is_null());
+        debug_assert_ne!(ptr.cast::<c_void>().cast_const(), unsafe {
+            UA_EMPTY_ARRAY_SENTINEL
+        });
+
+        let ptr = mem::replace(ptr, ptr::null_mut());
+        let size = mem::replace(size, 0);
+
+        // SAFETY: We checked preconditions above.
+        Some(Self(State::NonEmpty {
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            size: unsafe { NonZeroUsize::new_unchecked(size) },
+        }))
+    }
+
     /// Creates slice from existing raw parts.
     ///
     /// # Safety

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -37,6 +37,8 @@ mod localized_text;
 mod message_security_mode;
 mod monitored_item_create_request;
 mod monitored_item_create_result;
+mod monitoring_mode;
+mod monitoring_parameters;
 mod node_attributes;
 mod node_class;
 mod node_id;
@@ -95,6 +97,8 @@ pub use self::{
     message_security_mode::MessageSecurityMode,
     monitored_item_create_request::MonitoredItemCreateRequest,
     monitored_item_create_result::MonitoredItemCreateResult,
+    monitoring_mode::MonitoringMode,
+    monitoring_parameters::MonitoringParameters,
     node_attributes::{
         DataTypeAttributes, MethodAttributes, NodeAttributes, ObjectAttributes,
         ObjectTypeAttributes, ReferenceTypeAttributes, VariableAttributes, VariableTypeAttributes,

--- a/src/ua/data_types/create_monitored_items_request.rs
+++ b/src/ua/data_types/create_monitored_items_request.rs
@@ -19,6 +19,7 @@ impl CreateMonitoredItemsRequest {
         self
     }
 
+    #[allow(dead_code)] // --no-default-features
     #[must_use]
     pub(crate) fn items_to_create(&self) -> Option<&[ua::MonitoredItemCreateRequest]> {
         unsafe { ua::Array::slice_from_raw_parts(self.0.itemsToCreateSize, self.0.itemsToCreate) }

--- a/src/ua/data_types/create_monitored_items_request.rs
+++ b/src/ua/data_types/create_monitored_items_request.rs
@@ -18,4 +18,9 @@ impl CreateMonitoredItemsRequest {
         array.move_into_raw(&mut self.0.itemsToCreateSize, &mut self.0.itemsToCreate);
         self
     }
+
+    #[must_use]
+    pub(crate) fn items_to_create(&self) -> Option<&[ua::MonitoredItemCreateRequest]> {
+        unsafe { ua::Array::slice_from_raw_parts(self.0.itemsToCreateSize, self.0.itemsToCreate) }
+    }
 }

--- a/src/ua/data_types/create_monitored_items_response.rs
+++ b/src/ua/data_types/create_monitored_items_response.rs
@@ -3,19 +3,12 @@ use crate::ua;
 crate::data_type!(CreateMonitoredItemsResponse);
 
 impl CreateMonitoredItemsResponse {
-    #[must_use]
-    pub fn monitored_item_ids(&self) -> Option<Vec<ua::MonitoredItemId>> {
-        let results = ua::Array::<ua::MonitoredItemCreateResult>::from_raw_parts(
-            self.0.resultsSize,
-            self.0.results,
-        )?;
+    #[allow(dead_code)] // This is unused for now.
+    pub(crate) fn results(&self) -> Option<&[ua::MonitoredItemCreateResult]> {
+        unsafe { ua::Array::slice_from_raw_parts(self.0.resultsSize, self.0.results) }
+    }
 
-        let monitored_item_ids: Vec<_> = results
-            .as_slice()
-            .iter()
-            .map(ua::MonitoredItemCreateResult::monitored_item_id)
-            .collect();
-
-        Some(monitored_item_ids)
+    pub(crate) fn into_results(mut self) -> Option<ua::Array<ua::MonitoredItemCreateResult>> {
+        unsafe { ua::Array::move_from_raw_parts(&mut self.0.resultsSize, &mut self.0.results) }
     }
 }

--- a/src/ua/data_types/create_monitored_items_response.rs
+++ b/src/ua/data_types/create_monitored_items_response.rs
@@ -8,6 +8,7 @@ impl CreateMonitoredItemsResponse {
         unsafe { ua::Array::slice_from_raw_parts(self.0.resultsSize, self.0.results) }
     }
 
+    #[allow(dead_code)] // --no-default-features
     pub(crate) fn into_results(mut self) -> Option<ua::Array<ua::MonitoredItemCreateResult>> {
         unsafe { ua::Array::move_from_raw_parts(&mut self.0.resultsSize, &mut self.0.results) }
     }

--- a/src/ua/data_types/create_subscription_request.rs
+++ b/src/ua/data_types/create_subscription_request.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroU32, time::Duration};
 
 use open62541_sys::UA_CreateSubscriptionRequest_default;
 
@@ -7,14 +7,19 @@ crate::data_type!(CreateSubscriptionRequest);
 impl CreateSubscriptionRequest {
     /// Sets requested publishing interval.
     ///
-    /// The value `Duration::ZERO` indicates that the server shall revise with the fastest supported
+    /// The value `None` indicates that the server shall revise with the fastest supported
     /// publishing interval
     #[must_use]
     pub fn with_requested_publishing_interval(
         mut self,
-        requested_publishing_interval: Duration,
+        requested_publishing_interval: Option<Duration>,
     ) -> Self {
-        self.0.requestedPublishingInterval = requested_publishing_interval.as_secs_f64() * 1e3;
+        // The special value `0` (or negative) indicates that the server shall revise with the
+        // fastest supported publishing interval.
+        self.0.requestedPublishingInterval = requested_publishing_interval
+            .map_or(0.0, |requested_publishing_interval| {
+                requested_publishing_interval.as_secs_f64() * 1e3
+            });
         self
     }
 
@@ -27,27 +32,32 @@ impl CreateSubscriptionRequest {
 
     /// Sets requested maximum keep-alive count.
     ///
-    /// The value `0` indicates that the server shall revise with the smallest supported keep-alive
-    /// count.
+    /// The value `None` indicates that the server shall revise with the smallest supported
+    /// keep-alive count.
     #[must_use]
-    pub const fn with_requested_max_keep_alive_count(
+    pub fn with_requested_max_keep_alive_count(
         mut self,
-        requested_max_keep_alive_count: u32,
+        requested_max_keep_alive_count: Option<NonZeroU32>,
     ) -> Self {
-        self.0.requestedMaxKeepAliveCount = requested_max_keep_alive_count;
+        // The special value `0` indicates that the server shall revise with the smallest supported
+        // keep-alive count.
+        self.0.requestedMaxKeepAliveCount =
+            requested_max_keep_alive_count.map_or(0, NonZeroU32::get);
         self
     }
 
     /// Sets maximum number of notifications that the client wishes to receive in a single publish
     /// response.
     ///
-    /// The value `0` indicates that there is no limit.
+    /// The value `None` indicates that there is no limit.
     #[must_use]
-    pub const fn with_max_notifications_per_publish(
+    pub fn with_max_notifications_per_publish(
         mut self,
-        max_notifications_per_publish: u32,
+        max_notifications_per_publish: Option<NonZeroU32>,
     ) -> Self {
-        self.0.maxNotificationsPerPublish = max_notifications_per_publish;
+        // The special value `0` indicates that there is no limit.
+        self.0.maxNotificationsPerPublish =
+            max_notifications_per_publish.map_or(0, NonZeroU32::get);
         self
     }
 

--- a/src/ua/data_types/create_subscription_request.rs
+++ b/src/ua/data_types/create_subscription_request.rs
@@ -1,6 +1,70 @@
+use std::time::Duration;
+
 use open62541_sys::UA_CreateSubscriptionRequest_default;
 
 crate::data_type!(CreateSubscriptionRequest);
+
+impl CreateSubscriptionRequest {
+    /// Sets requested publishing interval.
+    ///
+    /// The value `Some(Duration::ZERO)` indicates that the server shall revise with the fastest
+    /// supported publishing interval
+    #[must_use]
+    pub fn with_requested_publishing_interval(
+        mut self,
+        requested_publishing_interval: Duration,
+    ) -> Self {
+        self.0.requestedPublishingInterval = requested_publishing_interval.as_secs_f64() * 1e3;
+        self
+    }
+
+    /// Sets requested lifetime count.
+    #[must_use]
+    pub const fn with_requested_lifetime_count(mut self, requested_lifetime_count: u32) -> Self {
+        self.0.requestedLifetimeCount = requested_lifetime_count;
+        self
+    }
+
+    /// Sets requested maximum keep-alive count.
+    ///
+    /// The value `0` indicates that the server shall revise with the smallest supported keep-alive
+    /// count.
+    #[must_use]
+    pub const fn with_requested_max_keep_alive_count(
+        mut self,
+        requested_max_keep_alive_count: u32,
+    ) -> Self {
+        self.0.requestedMaxKeepAliveCount = requested_max_keep_alive_count;
+        self
+    }
+
+    /// Sets maximum number of notifications that the client wishes to receive in a single publish
+    /// response.
+    ///
+    /// The value `0` indicates that there is no limit.
+    #[must_use]
+    pub const fn with_max_notifications_per_publish(
+        mut self,
+        max_notifications_per_publish: u32,
+    ) -> Self {
+        self.0.maxNotificationsPerPublish = max_notifications_per_publish;
+        self
+    }
+
+    /// Enables or disables publishing.
+    #[must_use]
+    pub const fn with_publishing_enabled(mut self, publishing_enabled: bool) -> Self {
+        self.0.publishingEnabled = publishing_enabled;
+        self
+    }
+
+    /// Sets relative priority of the subscription.
+    #[must_use]
+    pub const fn with_priority(mut self, priority: u8) -> Self {
+        self.0.priority = priority;
+        self
+    }
+}
 
 impl Default for CreateSubscriptionRequest {
     fn default() -> Self {

--- a/src/ua/data_types/create_subscription_request.rs
+++ b/src/ua/data_types/create_subscription_request.rs
@@ -7,8 +7,8 @@ crate::data_type!(CreateSubscriptionRequest);
 impl CreateSubscriptionRequest {
     /// Sets requested publishing interval.
     ///
-    /// The value `Some(Duration::ZERO)` indicates that the server shall revise with the fastest
-    /// supported publishing interval
+    /// The value `Duration::ZERO` indicates that the server shall revise with the fastest supported
+    /// publishing interval
     #[must_use]
     pub fn with_requested_publishing_interval(
         mut self,

--- a/src/ua/data_types/create_subscription_respones.rs
+++ b/src/ua/data_types/create_subscription_respones.rs
@@ -1,4 +1,6 @@
-use crate::ua;
+use std::time::Duration;
+
+use crate::{ua, Error, Result};
 
 crate::data_type!(CreateSubscriptionResponse);
 
@@ -6,5 +8,27 @@ impl CreateSubscriptionResponse {
     #[must_use]
     pub const fn subscription_id(&self) -> ua::SubscriptionId {
         ua::SubscriptionId::new(self.0.subscriptionId)
+    }
+
+    /// Gets revised publishing interval.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the returned value is negative.
+    pub fn revised_publishing_interval(&self) -> Result<Duration> {
+        Duration::try_from_secs_f64(self.0.revisedPublishingInterval / 1e3)
+            .map_err(|_| Error::internal("invalid revised publishing interval"))
+    }
+
+    /// Gets revised lifetime count.
+    #[must_use]
+    pub const fn revised_lifetime_count(&self) -> u32 {
+        self.0.revisedLifetimeCount
+    }
+
+    /// Gets revised maximum keep-alive count.
+    #[must_use]
+    pub const fn revised_max_keep_alive_count(&self) -> u32 {
+        self.0.revisedMaxKeepAliveCount
     }
 }

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use open62541_sys::{UA_MonitoredItemCreateRequest_default, UA_NODEID_NUMERIC};
 
 use crate::{ua, DataType as _};
@@ -5,16 +7,28 @@ use crate::{ua, DataType as _};
 crate::data_type!(MonitoredItemCreateRequest);
 
 impl MonitoredItemCreateRequest {
+    /// Sets item to monitor.
+    #[must_use]
+    pub fn with_item_to_monitor(mut self, item_to_monitor: &ua::ReadValueId) -> Self {
+        item_to_monitor.clone_into_raw(&mut self.0.itemToMonitor);
+        self
+    }
+
+    /// Shortcut for setting node ID.
+    ///
+    /// See [`ua::ReadValueId::with_node_id()`].
     #[must_use]
     pub fn with_node_id(mut self, node_id: &ua::NodeId) -> Self {
         node_id.clone_into_raw(&mut self.0.itemToMonitor.nodeId);
         self
     }
 
-    /// Sets item to monitor.
+    /// Shortcut for setting attribute ID.
+    ///
+    /// See [`ua::ReadValueId::with_attribute_id()`].
     #[must_use]
-    pub fn with_item_to_monitor(mut self, item_to_monitor: &ua::ReadValueId) -> Self {
-        item_to_monitor.clone_into_raw(&mut self.0.itemToMonitor);
+    pub fn with_attribute_id(mut self, attribute_id: &ua::AttributeId) -> Self {
+        self.0.itemToMonitor.attributeId = attribute_id.as_u32();
         self
     }
 
@@ -32,6 +46,38 @@ impl MonitoredItemCreateRequest {
         requested_parameters: &ua::MonitoringParameters,
     ) -> Self {
         requested_parameters.clone_into_raw(&mut self.0.requestedParameters);
+        self
+    }
+
+    /// Shortcut for setting sampling interval.
+    ///
+    /// See [`ua::MonitoringParameters::with_sampling_interval()`].
+    #[must_use]
+    pub const fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
+        self.0.requestedParameters.samplingInterval =
+            if let Some(sampling_interval) = sampling_interval {
+                sampling_interval.as_secs_f64() * 1e3
+            } else {
+                -1.0
+            };
+        self
+    }
+
+    /// Shortcut for setting requested size of the monitored item queue.
+    ///
+    /// See [`ua::MonitoringParameters::with_queue_size()`].
+    #[must_use]
+    pub const fn with_queue_size(mut self, queue_size: u32) -> Self {
+        self.0.requestedParameters.queueSize = queue_size;
+        self
+    }
+
+    /// Shortcut for setting discard policy.
+    ///
+    /// See [`ua::MonitoringParameters::with_discard_oldest()`].
+    #[must_use]
+    pub const fn with_discard_oldest(mut self, discard_oldest: bool) -> Self {
+        self.0.requestedParameters.discardOldest = discard_oldest;
         self
     }
 }

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -53,7 +53,7 @@ impl MonitoredItemCreateRequest {
     ///
     /// See [`ua::MonitoringParameters::with_sampling_interval()`].
     #[must_use]
-    pub const fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
+    pub fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
         self.0.requestedParameters.samplingInterval =
             if let Some(sampling_interval) = sampling_interval {
                 sampling_interval.as_secs_f64() * 1e3

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -10,6 +10,30 @@ impl MonitoredItemCreateRequest {
         node_id.clone_into_raw(&mut self.0.itemToMonitor.nodeId);
         self
     }
+
+    /// Sets item to monitor.
+    #[must_use]
+    pub fn with_item_to_monitor(mut self, item_to_monitor: &ua::ReadValueId) -> Self {
+        item_to_monitor.clone_into_raw(&mut self.0.itemToMonitor);
+        self
+    }
+
+    /// Sets monitoring mode.
+    #[must_use]
+    pub fn with_monitoring_mode(mut self, monitoring_mode: &ua::MonitoringMode) -> Self {
+        monitoring_mode.clone_into_raw(&mut self.0.monitoringMode);
+        self
+    }
+
+    /// Sets requested parameters.
+    #[must_use]
+    pub fn with_requested_parameters(
+        mut self,
+        requested_parameters: &ua::MonitoringParameters,
+    ) -> Self {
+        requested_parameters.clone_into_raw(&mut self.0.requestedParameters);
+        self
+    }
 }
 
 impl Default for MonitoredItemCreateRequest {

--- a/src/ua/data_types/monitored_item_create_result.rs
+++ b/src/ua/data_types/monitored_item_create_result.rs
@@ -5,11 +5,13 @@ use crate::{ua, Error, Result};
 crate::data_type!(MonitoredItemCreateResult);
 
 impl MonitoredItemCreateResult {
+    #[allow(dead_code)] // --no-default-features
     #[must_use]
     pub(crate) const fn status_code(&self) -> ua::StatusCode {
         ua::StatusCode::new(self.0.statusCode)
     }
 
+    #[allow(dead_code)] // --no-default-features
     #[must_use]
     pub(crate) const fn monitored_item_id(&self) -> ua::MonitoredItemId {
         ua::MonitoredItemId::new(self.0.monitoredItemId)

--- a/src/ua/data_types/monitored_item_create_result.rs
+++ b/src/ua/data_types/monitored_item_create_result.rs
@@ -6,12 +6,12 @@ crate::data_type!(MonitoredItemCreateResult);
 
 impl MonitoredItemCreateResult {
     #[must_use]
-    pub const fn status_code(&self) -> ua::StatusCode {
+    pub(crate) const fn status_code(&self) -> ua::StatusCode {
         ua::StatusCode::new(self.0.statusCode)
     }
 
     #[must_use]
-    pub const fn monitored_item_id(&self) -> ua::MonitoredItemId {
+    pub(crate) const fn monitored_item_id(&self) -> ua::MonitoredItemId {
         ua::MonitoredItemId::new(self.0.monitoredItemId)
     }
 

--- a/src/ua/data_types/monitored_item_create_result.rs
+++ b/src/ua/data_types/monitored_item_create_result.rs
@@ -1,10 +1,33 @@
-use crate::ua;
+use std::time::Duration;
+
+use crate::{ua, Error, Result};
 
 crate::data_type!(MonitoredItemCreateResult);
 
 impl MonitoredItemCreateResult {
     #[must_use]
+    pub const fn status_code(&self) -> ua::StatusCode {
+        ua::StatusCode::new(self.0.statusCode)
+    }
+
+    #[must_use]
     pub const fn monitored_item_id(&self) -> ua::MonitoredItemId {
         ua::MonitoredItemId::new(self.0.monitoredItemId)
+    }
+
+    /// Gets revised sampling interval.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the returned value is negative.
+    pub fn revised_sampling_interval(&self) -> Result<Duration> {
+        Duration::try_from_secs_f64(self.0.revisedSamplingInterval / 1e3)
+            .map_err(|_| Error::internal("invalid revised sampling interval"))
+    }
+
+    /// Gets revised queue size.
+    #[must_use]
+    pub const fn revised_queue_size(&self) -> u32 {
+        self.0.revisedQueueSize
     }
 }

--- a/src/ua/data_types/monitoring_mode.rs
+++ b/src/ua/data_types/monitoring_mode.rs
@@ -1,0 +1,7 @@
+crate::data_type!(MonitoringMode);
+
+crate::enum_variants!(
+    MonitoringMode,
+    UA_MonitoringMode,
+    [DISABLED, SAMPLING, REPORTING]
+);

--- a/src/ua/data_types/monitoring_parameters.rs
+++ b/src/ua/data_types/monitoring_parameters.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+
+crate::data_type!(MonitoringParameters);
+
+impl MonitoringParameters {
+    /// Sets sampling interval.
+    ///
+    /// The value `Some(Duration::ZERO)` indicates that the server should use the fastest practical
+    /// rate.
+    ///
+    /// The value `None` (-1) indicates that the default sampling interval defined by the publishing
+    /// interval of the subscription is requested.
+    #[must_use]
+    pub const fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
+        self.0.samplingInterval = if let Some(sampling_interval) = sampling_interval {
+            sampling_interval.as_secs_f64() * 1e3
+        } else {
+            -1.0
+        };
+        self
+    }
+
+    /// Sets requested size of the monitored item queue.
+    #[must_use]
+    pub const fn with_queue_size(mut self, queue_size: u32) -> Self {
+        self.0.queueSize = queue_size;
+        self
+    }
+
+    /// Sets discard policy.
+    ///
+    /// When `true`, the oldest notification in the queue is discarded and the new notification is
+    /// added to the end of the queue. When `false`, the last notification added to the queue gets
+    /// replaced with the new notification.
+    #[must_use]
+    pub const fn with_discard_oldest(mut self, discard_oldest: bool) -> Self {
+        self.0.discardOldest = discard_oldest;
+        self
+    }
+}

--- a/src/ua/data_types/monitoring_parameters.rs
+++ b/src/ua/data_types/monitoring_parameters.rs
@@ -11,7 +11,7 @@ impl MonitoringParameters {
     /// The value `None` (-1) indicates that the default sampling interval defined by the publishing
     /// interval of the subscription is requested.
     #[must_use]
-    pub const fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
+    pub fn with_sampling_interval(mut self, sampling_interval: Option<Duration>) -> Self {
         self.0.samplingInterval = if let Some(sampling_interval) = sampling_interval {
             sampling_interval.as_secs_f64() * 1e3
         } else {

--- a/src/ua/monitored_item_id.rs
+++ b/src/ua/monitored_item_id.rs
@@ -5,6 +5,7 @@ use crate::ua;
 pub struct MonitoredItemId(u32);
 
 impl MonitoredItemId {
+    #[allow(dead_code)] // --no-default-features
     #[must_use]
     pub(crate) const fn new(id: u32) -> Self {
         Self(id)


### PR DESCRIPTION
## Description

This adds the ability to set custom parameters when creating subscriptions and monitored items, such as publishing and sampling intervals, queue sizes, discard policy etc.