### PR TITLE
Allow setting monitored item filter and attribute ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add method `MonitoredItemBuilder::attribute_id()` to set a different attribute ID to monitor.
+- Add method `MonitoredItemBuilder::filter()` and related data types `ua::DataChangeFilter`,
+  `ua::EventFilter`, `ua::AggregateFilter` along with associated data types.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add method `MonitoredItemBuilder::attribute_id()` to set a different attribute ID to monitor.
+
 ### Changed
 
 - Upgrade to open62541 version [1.4.9](https://github.com/open62541/open62541/releases/tag/v1.4.9).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,9 @@ pub use self::{
         MethodCallback, MethodCallbackContext, MethodCallbackError, MethodCallbackResult,
         MethodNode, Node, ObjectNode, Server, ServerBuilder, ServerRunner, VariableNode,
     },
-    traits::{Attribute, Attributes, CustomCertificateVerification},
+    traits::{
+        Attribute, Attributes, CustomCertificateVerification, FilterOperand, MonitoringFilter,
+    },
     userdata::{Userdata, UserdataSentinel},
     value::{ScalarValue, ValueType, VariantValue},
 };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -54,3 +54,29 @@ pub trait CustomCertificateVerification {
         application_uri: &ua::String,
     ) -> ua::StatusCode;
 }
+
+/// Monitoring filter.
+///
+/// This is used as extensible parameter in [`ua::MonitoringParameters::with_filter()`].
+pub trait MonitoringFilter: fmt::Debug + Send + Sync + 'static {
+    fn to_extension_object(&self) -> ua::ExtensionObject;
+}
+
+impl MonitoringFilter for Box<dyn MonitoringFilter> {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        (**self).to_extension_object()
+    }
+}
+
+/// Filter operand.
+///
+/// This is used as extensible parameter in [`ua::ContentFilterElement::with_filter_operands()`].
+pub trait FilterOperand: fmt::Debug + Send + Sync + 'static {
+    fn to_extension_object(&self) -> ua::ExtensionObject;
+}
+
+impl FilterOperand for Box<dyn FilterOperand> {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        (**self).to_extension_object()
+    }
+}

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -1,10 +1,12 @@
 //! Thin wrappers for OPC UA data types from [`open62541_sys`].
 
+mod aggregate_filter;
 mod anonymous_identity_token;
 mod application_description;
 mod application_type;
 mod argument;
 mod attribute_id;
+mod attribute_operand;
 mod browse_description;
 mod browse_direction;
 mod browse_next_request;
@@ -20,19 +22,26 @@ mod call_method_request;
 mod call_method_result;
 mod call_request;
 mod call_response;
+mod content_filter;
+mod content_filter_element;
 mod create_monitored_items_request;
 mod create_monitored_items_response;
 mod create_subscription_request;
 mod create_subscription_respones;
+mod data_change_filter;
 mod data_value;
 mod date_time;
 mod delete_monitored_items_request;
 mod delete_monitored_items_response;
 mod delete_subscriptions_request;
 mod delete_subscriptions_response;
+mod element_operand;
 mod endpoint_description;
+mod event_filter;
 mod expanded_node_id;
 mod extension_object;
+mod filter_operator;
+mod literal_operand;
 mod localized_text;
 mod message_security_mode;
 mod monitored_item_create_request;
@@ -50,6 +59,7 @@ mod read_value_id;
 mod reference_description;
 mod relative_path;
 mod relative_path_element;
+mod simple_attribute_operand;
 mod status_code;
 mod string;
 mod timestamps_to_return;
@@ -60,11 +70,13 @@ mod write_response;
 mod write_value;
 
 pub use self::{
+    aggregate_filter::AggregateFilter,
     anonymous_identity_token::AnonymousIdentityToken,
     application_description::ApplicationDescription,
     application_type::ApplicationType,
     argument::Argument,
     attribute_id::AttributeId,
+    attribute_operand::AttributeOperand,
     browse_description::BrowseDescription,
     browse_direction::BrowseDirection,
     browse_next_request::BrowseNextRequest,
@@ -80,19 +92,26 @@ pub use self::{
     call_method_result::CallMethodResult,
     call_request::CallRequest,
     call_response::CallResponse,
+    content_filter::ContentFilter,
+    content_filter_element::ContentFilterElement,
     create_monitored_items_request::CreateMonitoredItemsRequest,
     create_monitored_items_response::CreateMonitoredItemsResponse,
     create_subscription_request::CreateSubscriptionRequest,
     create_subscription_respones::CreateSubscriptionResponse,
+    data_change_filter::DataChangeFilter,
     data_value::DataValue,
     date_time::DateTime,
     delete_monitored_items_request::DeleteMonitoredItemsRequest,
     delete_monitored_items_response::DeleteMonitoredItemsResponse,
     delete_subscriptions_request::DeleteSubscriptionsRequest,
     delete_subscriptions_response::DeleteSubscriptionsResponse,
+    element_operand::ElementOperand,
     endpoint_description::EndpointDescription,
+    event_filter::EventFilter,
     expanded_node_id::ExpandedNodeId,
     extension_object::ExtensionObject,
+    filter_operator::FilterOperator,
+    literal_operand::LiteralOperand,
     localized_text::LocalizedText,
     message_security_mode::MessageSecurityMode,
     monitored_item_create_request::MonitoredItemCreateRequest,
@@ -114,6 +133,7 @@ pub use self::{
     reference_description::ReferenceDescription,
     relative_path::RelativePath,
     relative_path_element::RelativePathElement,
+    simple_attribute_operand::SimpleAttributeOperand,
     status_code::StatusCode,
     string::String,
     timestamps_to_return::TimestampsToReturn,

--- a/src/ua/data_types/aggregate_filter.rs
+++ b/src/ua/data_types/aggregate_filter.rs
@@ -1,0 +1,9 @@
+use crate::{ua, MonitoringFilter};
+
+crate::data_type!(AggregateFilter);
+
+impl MonitoringFilter for AggregateFilter {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/attribute_operand.rs
+++ b/src/ua/data_types/attribute_operand.rs
@@ -1,0 +1,9 @@
+use crate::{ua, FilterOperand};
+
+crate::data_type!(AttributeOperand);
+
+impl FilterOperand for AttributeOperand {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/content_filter.rs
+++ b/src/ua/data_types/content_filter.rs
@@ -1,0 +1,12 @@
+use crate::ua;
+
+crate::data_type!(ContentFilter);
+
+impl ContentFilter {
+    #[must_use]
+    pub fn with_elements(mut self, elements: &[ua::ContentFilterElement]) -> Self {
+        let array = ua::Array::from_slice(elements);
+        array.move_into_raw(&mut self.0.elementsSize, &mut self.0.elements);
+        self
+    }
+}

--- a/src/ua/data_types/content_filter_element.rs
+++ b/src/ua/data_types/content_filter_element.rs
@@ -1,0 +1,22 @@
+use crate::{ua, DataType, FilterOperand};
+
+crate::data_type!(ContentFilterElement);
+
+impl ContentFilterElement {
+    #[must_use]
+    pub fn with_filter_operator(mut self, filter_operator: ua::FilterOperator) -> Self {
+        filter_operator.move_into_raw(&mut self.0.filterOperator);
+        self
+    }
+
+    #[must_use]
+    pub fn with_filter_operands(mut self, filter_operands: &[impl FilterOperand]) -> Self {
+        let array = ua::Array::from_iter(
+            filter_operands
+                .iter()
+                .map(FilterOperand::to_extension_object),
+        );
+        array.move_into_raw(&mut self.0.filterOperandsSize, &mut self.0.filterOperands);
+        self
+    }
+}

--- a/src/ua/data_types/data_change_filter.rs
+++ b/src/ua/data_types/data_change_filter.rs
@@ -1,0 +1,9 @@
+use crate::{ua, MonitoringFilter};
+
+crate::data_type!(DataChangeFilter);
+
+impl MonitoringFilter for DataChangeFilter {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/element_operand.rs
+++ b/src/ua/data_types/element_operand.rs
@@ -1,0 +1,9 @@
+use crate::{ua, FilterOperand};
+
+crate::data_type!(ElementOperand);
+
+impl FilterOperand for ElementOperand {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/event_filter.rs
+++ b/src/ua/data_types/event_filter.rs
@@ -1,0 +1,24 @@
+use crate::{ua, DataType as _, MonitoringFilter};
+
+crate::data_type!(EventFilter);
+
+impl EventFilter {
+    #[must_use]
+    pub fn with_select_clauses(mut self, select_clauses: &[ua::SimpleAttributeOperand]) -> Self {
+        let array = ua::Array::from_slice(select_clauses);
+        array.move_into_raw(&mut self.0.selectClausesSize, &mut self.0.selectClauses);
+        self
+    }
+
+    #[must_use]
+    pub fn with_where_clause(mut self, where_clause: ua::ContentFilter) -> Self {
+        where_clause.move_into_raw(&mut self.0.whereClause);
+        self
+    }
+}
+
+impl MonitoringFilter for EventFilter {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/filter_operator.rs
+++ b/src/ua/data_types/filter_operator.rs
@@ -1,0 +1,34 @@
+use std::hash;
+
+crate::data_type!(FilterOperator, UInt32);
+
+crate::enum_variants!(
+    FilterOperator,
+    UA_FilterOperator,
+    [
+        EQUALS,
+        ISNULL,
+        GREATERTHAN,
+        LESSTHAN,
+        GREATERTHANOREQUAL,
+        LESSTHANOREQUAL,
+        LIKE,
+        NOT,
+        BETWEEN,
+        INLIST,
+        AND,
+        OR,
+        CAST,
+        INVIEW,
+        OFTYPE,
+        RELATEDTO,
+        BITWISEAND,
+        BITWISEOR,
+    ]
+);
+
+impl hash::Hash for FilterOperator {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}

--- a/src/ua/data_types/literal_operand.rs
+++ b/src/ua/data_types/literal_operand.rs
@@ -1,0 +1,18 @@
+use crate::{ua, DataType as _, FilterOperand};
+
+crate::data_type!(LiteralOperand);
+
+impl LiteralOperand {
+    #[must_use]
+    pub fn new(value: ua::Variant) -> Self {
+        let mut inner = Self::init();
+        value.move_into_raw(&mut inner.0.value);
+        inner
+    }
+}
+
+impl FilterOperand for LiteralOperand {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use open62541_sys::{UA_MonitoredItemCreateRequest_default, UA_NODEID_NUMERIC};
 
-use crate::{ua, DataType as _};
+use crate::{ua, DataType as _, MonitoringFilter};
 
 crate::data_type!(MonitoredItemCreateRequest);
 
@@ -60,6 +60,15 @@ impl MonitoredItemCreateRequest {
             } else {
                 -1.0
             };
+        self
+    }
+
+    /// Shortcut for setting filter.
+    #[must_use]
+    pub fn with_filter(mut self, filter: &impl MonitoringFilter) -> Self {
+        filter
+            .to_extension_object()
+            .move_into_raw(&mut self.0.requestedParameters.filter);
         self
     }
 

--- a/src/ua/data_types/monitoring_parameters.rs
+++ b/src/ua/data_types/monitoring_parameters.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use crate::{DataType as _, MonitoringFilter};
+
 crate::data_type!(MonitoringParameters);
 
 impl MonitoringParameters {
@@ -17,6 +19,15 @@ impl MonitoringParameters {
         } else {
             -1.0
         };
+        self
+    }
+
+    /// Sets filter.
+    #[must_use]
+    pub fn with_filter(mut self, filter: &impl MonitoringFilter) -> Self {
+        filter
+            .to_extension_object()
+            .move_into_raw(&mut self.0.filter);
         self
     }
 

--- a/src/ua/data_types/simple_attribute_operand.rs
+++ b/src/ua/data_types/simple_attribute_operand.rs
@@ -1,0 +1,36 @@
+use crate::{ua, DataType, FilterOperand};
+
+crate::data_type!(SimpleAttributeOperand);
+
+impl SimpleAttributeOperand {
+    #[must_use]
+    pub fn with_type_definition_id(mut self, type_definition_id: ua::NodeId) -> Self {
+        type_definition_id.move_into_raw(&mut self.0.typeDefinitionId);
+        self
+    }
+
+    #[must_use]
+    pub fn with_browse_path(mut self, browse_path: &[ua::QualifiedName]) -> Self {
+        let array = ua::Array::from_slice(browse_path);
+        array.move_into_raw(&mut self.0.browsePathSize, &mut self.0.browsePath);
+        self
+    }
+
+    #[must_use]
+    pub fn with_attribute_id(mut self, attribute_id: &ua::AttributeId) -> Self {
+        self.0.attributeId = attribute_id.as_u32();
+        self
+    }
+
+    #[must_use]
+    pub fn with_index_range(mut self, index_range: ua::String) -> Self {
+        index_range.move_into_raw(&mut self.0.indexRange);
+        self
+    }
+}
+
+impl FilterOperand for SimpleAttributeOperand {
+    fn to_extension_object(&self) -> ua::ExtensionObject {
+        ua::ExtensionObject::new(self)
+    }
+}


### PR DESCRIPTION
## Description

This adds `MonitoredItemBuilder::filter()` to filter node events and `MonitoredItemBuilder::attribute_id()` to watch attributes other than node values. Most of the filter data types are stubs for now and can be expanded later.