### PR TITLE
Allow setting client security parameters before connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add method `MonitoredItemBuilder::attribute_id()` to set a different attribute ID to monitor.
 - Add method `MonitoredItemBuilder::filter()` and related data types `ua::DataChangeFilter`,
   `ua::EventFilter`, `ua::AggregateFilter` along with associated data types.
+- Add methods `ClientBuilder::security_mode()` and `ClientBuilder::security_policy_uri()` to select
+  security mode and security policy URI when filtering remote endpoints.
 
 ### Changed
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -111,6 +111,29 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets security mode.
+    #[must_use]
+    pub fn security_mode(mut self, security_mode: ua::MessageSecurityMode) -> Self {
+        security_mode.move_into_raw(&mut self.config_mut().securityMode);
+        self
+    }
+
+    /// Sets security policy URI.
+    ///
+    /// The known values are as follows:
+    ///
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#None`
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15` (deprecated)
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#Basic256` (deprecated)
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256`
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep`
+    /// - `http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss`
+    #[must_use]
+    pub fn security_policy_uri(mut self, security_policy_uri: ua::String) -> Self {
+        security_policy_uri.move_into_raw(&mut self.config_mut().securityPolicyUri);
+        self
+    }
+
     /// Sets secure channel life time.
     ///
     /// After this life time, the channel needs to be renewed.


### PR DESCRIPTION
## Description

This adds accessor methods to set security mode and security policy URI before connecting client, to filter the available remote endpoints as desired.