### PR TITLE
Upgrade to open62541 version 1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade to open62541 version [1.4.9](https://github.com/open62541/open62541/releases/tag/v1.4.9).
+- Upgrade to open62541 version
+  [1.4.10](https://github.com/open62541/open62541/releases/tag/v1.4.10).
 
 ## [0.7.2] - 2024-01-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6955f2df6a4ed9e16737d21d0450eeff148eedc0637afa42c73aa71841b0012"
+checksum = "35d434e1f5a192fc2d455582d3af15adef94111e328f2533fbae7a1e858d1d57"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.10"
+open62541-sys = "0.4.11"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest released version [1.4.10](https://github.com/open62541/open62541/releases/tag/v1.4.10) of [open62541](https://github.com/open62541/open62541).