### PR TITLE
Add missing `UserIdentityToken` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add method `with_policy_id()` to `ua::AnonymousIdentityToken` and `ua::UserNameIdentityToken`.
+- Add method `ua::UserNameIdentityToken::with_encryption_algorithm()`.
+- Add `ua::X509IdentityToken`.
+- Breaking: Add enum variant `UserIdentityToken::X509`.
+
 ## [0.7.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `ua::X509IdentityToken` and `ua::IssuedIdentityToken`.
 - Breaking: Add enum variants `X509` and `Issued` to `UserIdentityToken`.
 
+### Changed
+
+- Breaking: Expect `ua::String`, `ua::ByteString` in `ua::UserNameIdentityToken::with_user_name()`,
+  `ua::UserNameIdentityToken::with_password()`.
+
 ## [0.7.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add method `with_policy_id()` to `ua::AnonymousIdentityToken` and `ua::UserNameIdentityToken`.
 - Add method `ua::UserNameIdentityToken::with_encryption_algorithm()`.
-- Add `ua::X509IdentityToken`.
-- Breaking: Add enum variant `UserIdentityToken::X509`.
+- Add `ua::X509IdentityToken` and `ua::IssuedIdentityToken`.
+- Breaking: Add enum variants `X509` and `Issued` to `UserIdentityToken`.
 
 ## [0.7.3]
 

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -68,6 +68,7 @@ mod variant;
 mod write_request;
 mod write_response;
 mod write_value;
+mod x509_identity_token;
 
 pub use self::{
     aggregate_filter::AggregateFilter,
@@ -142,6 +143,7 @@ pub use self::{
     write_request::WriteRequest,
     write_response::WriteResponse,
     write_value::WriteValue,
+    x509_identity_token::X509IdentityToken,
 };
 
 macro_rules! primitive {

--- a/src/ua/data_types.rs
+++ b/src/ua/data_types.rs
@@ -41,6 +41,7 @@ mod event_filter;
 mod expanded_node_id;
 mod extension_object;
 mod filter_operator;
+mod issued_identity_token;
 mod literal_operand;
 mod localized_text;
 mod message_security_mode;
@@ -112,6 +113,7 @@ pub use self::{
     expanded_node_id::ExpandedNodeId,
     extension_object::ExtensionObject,
     filter_operator::FilterOperator,
+    issued_identity_token::IssuedIdentityToken,
     literal_operand::LiteralOperand,
     localized_text::LocalizedText,
     message_security_mode::MessageSecurityMode,

--- a/src/ua/data_types/anonymous_identity_token.rs
+++ b/src/ua/data_types/anonymous_identity_token.rs
@@ -1,1 +1,11 @@
+use crate::{ua, DataType as _};
+
 crate::data_type!(AnonymousIdentityToken);
+
+impl AnonymousIdentityToken {
+    /// Sets policy ID.
+    pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
+        policy_id.move_into_raw(&mut self.0.policyId);
+        self
+    }
+}

--- a/src/ua/data_types/anonymous_identity_token.rs
+++ b/src/ua/data_types/anonymous_identity_token.rs
@@ -4,6 +4,7 @@ crate::data_type!(AnonymousIdentityToken);
 
 impl AnonymousIdentityToken {
     /// Sets policy ID.
+    #[must_use]
     pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
         policy_id.move_into_raw(&mut self.0.policyId);
         self

--- a/src/ua/data_types/issued_identity_token.rs
+++ b/src/ua/data_types/issued_identity_token.rs
@@ -1,0 +1,23 @@
+use crate::{ua, DataType as _};
+
+crate::data_type!(IssuedIdentityToken);
+
+impl IssuedIdentityToken {
+    /// Sets policy ID.
+    pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
+        policy_id.move_into_raw(&mut self.0.policyId);
+        self
+    }
+
+    /// Sets token data.
+    pub fn with_token_data(mut self, token_data: ua::ByteString) -> Self {
+        token_data.move_into_raw(&mut self.0.tokenData);
+        self
+    }
+
+    /// Sets encryption algorithm.
+    pub fn with_encryption_algorithm(mut self, encryption_algorithm: ua::String) -> Self {
+        encryption_algorithm.move_into_raw(&mut self.0.encryptionAlgorithm);
+        self
+    }
+}

--- a/src/ua/data_types/issued_identity_token.rs
+++ b/src/ua/data_types/issued_identity_token.rs
@@ -4,18 +4,21 @@ crate::data_type!(IssuedIdentityToken);
 
 impl IssuedIdentityToken {
     /// Sets policy ID.
+    #[must_use]
     pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
         policy_id.move_into_raw(&mut self.0.policyId);
         self
     }
 
     /// Sets token data.
+    #[must_use]
     pub fn with_token_data(mut self, token_data: ua::ByteString) -> Self {
         token_data.move_into_raw(&mut self.0.tokenData);
         self
     }
 
     /// Sets encryption algorithm.
+    #[must_use]
     pub fn with_encryption_algorithm(mut self, encryption_algorithm: ua::String) -> Self {
         encryption_algorithm.move_into_raw(&mut self.0.encryptionAlgorithm);
         self

--- a/src/ua/data_types/user_name_identity_token.rs
+++ b/src/ua/data_types/user_name_identity_token.rs
@@ -6,11 +6,15 @@ impl UserNameIdentityToken {
     /// Creates token with user name and password.
     ///
     /// This is a shortcut for calling [`Self::with_user_name()`] and [`Self::with_password()`].
+    ///
+    /// # Panics
+    ///
+    /// The user name must not contain any NUL bytes.
     #[must_use]
     pub fn new(user_name: &str, password: &str) -> Self {
         Self::init()
-            .with_user_name(user_name)
-            .with_password(password)
+            .with_user_name(ua::String::new(user_name).unwrap())
+            .with_password(ua::ByteString::new(password.as_bytes()))
     }
 
     /// Sets policy ID.
@@ -20,28 +24,16 @@ impl UserNameIdentityToken {
     }
 
     /// Sets user name.
-    ///
-    /// # Panics
-    ///
-    /// The string must not contain any NUL bytes.
     #[must_use]
-    pub fn with_user_name(mut self, user_name: &str) -> Self {
-        ua::String::new(user_name)
-            .unwrap()
-            .move_into_raw(&mut self.0.userName);
+    pub fn with_user_name(mut self, user_name: ua::String) -> Self {
+        user_name.move_into_raw(&mut self.0.userName);
         self
     }
 
     /// Sets password.
-    ///
-    /// # Panics
-    ///
-    /// The string must not contain any NUL bytes.
     #[must_use]
-    pub fn with_password(mut self, password: &str) -> Self {
-        ua::String::new(password)
-            .unwrap()
-            .move_into_raw(&mut self.0.password);
+    pub fn with_password(mut self, password: ua::ByteString) -> Self {
+        password.move_into_raw(&mut self.0.password);
         self
     }
 

--- a/src/ua/data_types/user_name_identity_token.rs
+++ b/src/ua/data_types/user_name_identity_token.rs
@@ -18,6 +18,7 @@ impl UserNameIdentityToken {
     }
 
     /// Sets policy ID.
+    #[must_use]
     pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
         policy_id.move_into_raw(&mut self.0.policyId);
         self
@@ -38,6 +39,7 @@ impl UserNameIdentityToken {
     }
 
     /// Sets encryption algorithm.
+    #[must_use]
     pub fn with_encryption_algorithm(mut self, encryption_algorithm: ua::String) -> Self {
         encryption_algorithm.move_into_raw(&mut self.0.encryptionAlgorithm);
         self

--- a/src/ua/data_types/user_name_identity_token.rs
+++ b/src/ua/data_types/user_name_identity_token.rs
@@ -3,11 +3,20 @@ use crate::{ua, DataType as _};
 crate::data_type!(UserNameIdentityToken);
 
 impl UserNameIdentityToken {
+    /// Creates token with user name and password.
+    ///
+    /// This is a shortcut for calling [`Self::with_user_name()`] and [`Self::with_password()`].
     #[must_use]
     pub fn new(user_name: &str, password: &str) -> Self {
         Self::init()
             .with_user_name(user_name)
             .with_password(password)
+    }
+
+    /// Sets policy ID.
+    pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
+        policy_id.move_into_raw(&mut self.0.policyId);
+        self
     }
 
     /// Sets user name.
@@ -33,6 +42,12 @@ impl UserNameIdentityToken {
         ua::String::new(password)
             .unwrap()
             .move_into_raw(&mut self.0.password);
+        self
+    }
+
+    /// Sets encryption algorithm.
+    pub fn with_encryption_algorithm(mut self, encryption_algorithm: ua::String) -> Self {
+        encryption_algorithm.move_into_raw(&mut self.0.encryptionAlgorithm);
         self
     }
 }

--- a/src/ua/data_types/x509_identity_token.rs
+++ b/src/ua/data_types/x509_identity_token.rs
@@ -1,9 +1,10 @@
-use crate::{ua, Certificate, DataType as _};
+use crate::{ua, DataType as _};
 
 crate::data_type!(X509IdentityToken);
 
 impl X509IdentityToken {
     /// Sets policy ID.
+    #[must_use]
     pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
         policy_id.move_into_raw(&mut self.0.policyId);
         self
@@ -22,11 +23,14 @@ impl X509IdentityToken {
     ///
     /// This handles certificates in both [DER] and [PEM] format.
     ///
+    /// # Errors
+    ///
+    /// This fails when the certificate cannot be parsed or is invalid.
+    ///
     /// [DER]: https://en.wikipedia.org/wiki/X.690#DER_encoding
     /// [PEM]: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
     #[cfg(feature = "x509")]
-    #[must_use]
-    pub fn with_certificate(self, certificate: Certificate) -> crate::Result<Self> {
+    pub fn with_certificate(self, certificate: crate::Certificate) -> crate::Result<Self> {
         let certificate_data = certificate
             .into_x509()
             .map_err(|_| crate::Error::internal("unable to parse PEM certificate"))?

--- a/src/ua/data_types/x509_identity_token.rs
+++ b/src/ua/data_types/x509_identity_token.rs
@@ -1,0 +1,37 @@
+use crate::{ua, Certificate, DataType as _};
+
+crate::data_type!(X509IdentityToken);
+
+impl X509IdentityToken {
+    /// Sets policy ID.
+    pub fn with_policy_id(mut self, policy_id: ua::String) -> Self {
+        policy_id.move_into_raw(&mut self.0.policyId);
+        self
+    }
+
+    /// Sets certificate data ([DER] format).
+    ///
+    /// [DER]: https://en.wikipedia.org/wiki/X.690#DER_encoding
+    #[must_use]
+    pub fn with_certificate_data(mut self, certificate_data: ua::ByteString) -> Self {
+        certificate_data.move_into_raw(&mut self.0.certificateData);
+        self
+    }
+
+    /// Sets certificate data.
+    ///
+    /// This handles certificates in both [DER] and [PEM] format.
+    ///
+    /// [DER]: https://en.wikipedia.org/wiki/X.690#DER_encoding
+    /// [PEM]: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
+    #[cfg(feature = "x509")]
+    #[must_use]
+    pub fn with_certificate(self, certificate: Certificate) -> crate::Result<Self> {
+        let certificate_data = certificate
+            .into_x509()
+            .map_err(|_| crate::Error::internal("unable to parse PEM certificate"))?
+            .encode_der()
+            .map_err(|_| crate::Error::internal("unable to encode DER certificate"))?;
+        Ok(self.with_certificate_data(ua::ByteString::new(&certificate_data)))
+    }
+}

--- a/src/ua/data_types/x509_identity_token.rs
+++ b/src/ua/data_types/x509_identity_token.rs
@@ -29,7 +29,7 @@ impl X509IdentityToken {
     ///
     /// [DER]: https://en.wikipedia.org/wiki/X.690#DER_encoding
     /// [PEM]: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
-    #[cfg(feature = "x509")]
+    #[cfg(all(feature = "mbedtls", feature = "x509"))]
     pub fn with_certificate(self, certificate: crate::Certificate) -> crate::Result<Self> {
         let certificate_data = certificate
             .into_x509()

--- a/src/ua/user_identity_token.rs
+++ b/src/ua/user_identity_token.rs
@@ -4,13 +4,15 @@ use crate::ua;
 pub enum UserIdentityToken {
     Anonymous(ua::AnonymousIdentityToken),
     UserName(ua::UserNameIdentityToken),
+    X509(ua::X509IdentityToken),
 }
 
 impl UserIdentityToken {
     pub(crate) fn to_extension_object(&self) -> ua::ExtensionObject {
         match self {
-            UserIdentityToken::Anonymous(anonymous) => ua::ExtensionObject::new(anonymous),
-            UserIdentityToken::UserName(user_name) => ua::ExtensionObject::new(user_name),
+            Self::Anonymous(anonymous) => ua::ExtensionObject::new(anonymous),
+            Self::UserName(user_name) => ua::ExtensionObject::new(user_name),
+            Self::X509(x509) => ua::ExtensionObject::new(x509),
         }
     }
 }
@@ -24,5 +26,11 @@ impl From<ua::AnonymousIdentityToken> for UserIdentityToken {
 impl From<ua::UserNameIdentityToken> for UserIdentityToken {
     fn from(value: ua::UserNameIdentityToken) -> Self {
         Self::UserName(value)
+    }
+}
+
+impl From<ua::X509IdentityToken> for UserIdentityToken {
+    fn from(value: ua::X509IdentityToken) -> Self {
+        Self::X509(value)
     }
 }

--- a/src/ua/user_identity_token.rs
+++ b/src/ua/user_identity_token.rs
@@ -2,9 +2,14 @@ use crate::ua;
 
 #[derive(Debug)]
 pub enum UserIdentityToken {
+    /// No user information is available.
     Anonymous(ua::AnonymousIdentityToken),
+    /// A user identified by user name and password.
     UserName(ua::UserNameIdentityToken),
+    /// A user identified by an X.509 v3 Certificate.
     X509(ua::X509IdentityToken),
+    /// A user identified by a token issued by an external authorization service.
+    Issued(ua::IssuedIdentityToken),
 }
 
 impl UserIdentityToken {
@@ -13,6 +18,7 @@ impl UserIdentityToken {
             Self::Anonymous(anonymous) => ua::ExtensionObject::new(anonymous),
             Self::UserName(user_name) => ua::ExtensionObject::new(user_name),
             Self::X509(x509) => ua::ExtensionObject::new(x509),
+            Self::Issued(issued) => ua::ExtensionObject::new(issued),
         }
     }
 }

--- a/src/ua/user_identity_token.rs
+++ b/src/ua/user_identity_token.rs
@@ -40,3 +40,9 @@ impl From<ua::X509IdentityToken> for UserIdentityToken {
         Self::X509(value)
     }
 }
+
+impl From<ua::IssuedIdentityToken> for UserIdentityToken {
+    fn from(value: ua::IssuedIdentityToken) -> Self {
+        Self::Issued(value)
+    }
+}


### PR DESCRIPTION
## Description

This lays the foundation for supporting authentication by X.509 certificate and external authorization service tokens.