### PR TITLE
Remove deprecated GitHub runners for Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,6 @@ jobs:
             runner_os: macos-15
 
           - target: armv7-unknown-linux-gnueabihf
-            runner_os: ubuntu-20.04
-          - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-22.04
           - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-24.04
@@ -56,14 +54,10 @@ jobs:
             runner_os: windows-2022
 
           - target: x86_64-unknown-linux-gnu
-            runner_os: ubuntu-20.04
-          - target: x86_64-unknown-linux-gnu
             runner_os: ubuntu-22.04
           - target: x86_64-unknown-linux-gnu
             runner_os: ubuntu-24.04
 
-          - target: x86_64-unknown-linux-musl
-            runner_os: ubuntu-20.04
           - target: x86_64-unknown-linux-musl
             runner_os: ubuntu-22.04
           - target: x86_64-unknown-linux-musl


### PR DESCRIPTION
## Description

This removes the Ubuntu 20.04 runners that have been [deprecated](https://github.com/actions/runner-images/issues/11101) from our GitHub workflows.