### PR TITLE
Upgrade to open62541 version 1.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add wrapper data type `ua::Enumeration`.
 - Add `ValueType` variants `Structure` (inner type `ua::ExtensionObject`) and `Enumeration`.
 
+### Changed
+
+- Upgrade to open62541 version
+  [1.4.11](https://github.com/open62541/open62541/releases/tag/v1.4.11.1).
+
 ## [0.8.1] - 2025-03-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d434e1f5a192fc2d455582d3af15adef94111e328f2533fbae7a1e858d1d57"
+checksum = "40926370c646f3c20047f1b9d2b4a032e99519f46278f35d7e0daf38c0482796"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.4.11"
+open62541-sys = "0.4.13"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }
 serde_json = { version = "1.0.111", optional = true }


### PR DESCRIPTION
## Description

This upgrades to the latest release of [open62541-sys](https://github.com/HMIProject/open62541-sys) which includes an upgrade to the latest released version [1.4.11](https://github.com/open62541/open62541/releases/tag/v1.4.11.1) of [open62541](https://github.com/open62541/open62541).