### PR TITLE
Silence false-positive clippy warnings suggesting `const fn`

### DIFF
--- a/src/ssl.rs
+++ b/src/ssl.rs
@@ -39,6 +39,7 @@ impl Password {
         unsafe { self.0.as_bytes_unchecked() }
     }
 
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub(crate) fn as_byte_string(&self) -> &ua::ByteString {
         &self.0
     }
@@ -160,6 +161,7 @@ impl PrivateKey {
         unsafe { self.0.as_bytes_unchecked() }
     }
 
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub(crate) fn as_byte_string(&self) -> &ua::ByteString {
         &self.0
     }

--- a/src/ua/certificate_verification.rs
+++ b/src/ua/certificate_verification.rs
@@ -110,6 +110,7 @@ impl CertificateVerification {
     /// [`from_raw()`]: Self::from_raw
     /// [`UA_Client`]: open62541_sys::UA_Client
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub(crate) fn into_raw(self) -> UA_CertificateVerification {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.

--- a/src/ua/key_value_map.rs
+++ b/src/ua/key_value_map.rs
@@ -116,6 +116,7 @@ impl KeyValueMap {
 
     /// Gives up ownership and returns value.
     #[allow(dead_code)] // This is unused for now.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub(crate) fn into_raw(self) -> *mut UA_KeyValueMap {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.

--- a/src/ua/logger.rs
+++ b/src/ua/logger.rs
@@ -31,6 +31,7 @@ impl Logger {
     }
 
     /// Gives up ownership and returns value.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub(crate) fn into_raw(self) -> *mut UA_Logger {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.


### PR DESCRIPTION
This allows some instances of `clippy::missing_const_for_fn` where that lint is reporting that a function could be `const` when it really can't (adding `const` causes a compile error).