### PR TITLE
open62541: Implementation event Registration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ mod value;
 #[cfg(feature = "tokio")]
 pub use self::{
     async_client::AsyncClient,
-    async_monitored_item::{AsyncMonitoredItem, MonitoredItemBuilder},
+    async_monitored_item::{AsyncMonitoredItem, EventAsyncMonitoredItem, MonitoredItemBuilder},
     async_subscription::{AsyncSubscription, SubscriptionBuilder},
     callback::{CallbackOnce, CallbackStream},
 };

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -32,6 +32,11 @@ impl MonitoredItemCreateRequest {
         self
     }
 
+    #[must_use]
+    pub fn read_attribute_id(mut self) -> u32 {
+        self.0.itemToMonitor.attributeId
+    }
+
     /// Sets monitoring mode.
     #[must_use]
     pub fn with_monitoring_mode(mut self, monitoring_mode: &ua::MonitoringMode) -> Self {


### PR DESCRIPTION
The current implementation allows only data change registration. When setting up a event rigistration there is a crash because the wrong callback is executed. This modification solves the issue.