### PR TITLE
Fix lints for Rust 1.87

### DIFF
--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -403,12 +403,10 @@ macro_rules! data_type {
                 unsafe { (*ua_types).get(index) }.unwrap()
             }
 
-            #[must_use]
             unsafe fn from_raw(src: Self::Inner) -> Self {
                 $name(src)
             }
 
-            #[must_use]
             fn into_raw(self) -> Self::Inner {
                 // Use `ManuallyDrop` to avoid double-free even when added code might cause panic.
                 // See documentation of `mem::forget()` for details.

--- a/src/ssl.rs
+++ b/src/ssl.rs
@@ -39,7 +39,8 @@ impl Password {
         unsafe { self.0.as_bytes_unchecked() }
     }
 
-    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
+    #[expect(clippy::allow_attributes, reason = "non-static condition")]
+    #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn as_byte_string(&self) -> &ua::ByteString {
         &self.0
     }
@@ -161,7 +162,8 @@ impl PrivateKey {
         unsafe { self.0.as_bytes_unchecked() }
     }
 
-    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
+    #[expect(clippy::allow_attributes, reason = "non-static condition")]
+    #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn as_byte_string(&self) -> &ua::ByteString {
         &self.0
     }

--- a/src/ua/certificate_verification.rs
+++ b/src/ua/certificate_verification.rs
@@ -110,7 +110,8 @@ impl CertificateVerification {
     /// [`from_raw()`]: Self::from_raw
     /// [`UA_Client`]: open62541_sys::UA_Client
     #[must_use]
-    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
+    #[expect(clippy::allow_attributes, reason = "non-static condition")]
+    #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn into_raw(self) -> UA_CertificateVerification {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.

--- a/src/ua/key_value_map.rs
+++ b/src/ua/key_value_map.rs
@@ -116,7 +116,8 @@ impl KeyValueMap {
 
     /// Gives up ownership and returns value.
     #[expect(dead_code, reason = "unused for now")]
-    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
+    #[expect(clippy::allow_attributes, reason = "non-static condition")]
+    #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn into_raw(self) -> *mut UA_KeyValueMap {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.

--- a/src/ua/logger.rs
+++ b/src/ua/logger.rs
@@ -31,7 +31,8 @@ impl Logger {
     }
 
     /// Gives up ownership and returns value.
-    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
+    #[expect(clippy::allow_attributes, reason = "non-static condition")]
+    #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn into_raw(self) -> *mut UA_Logger {
         // Use `ManuallyDrop` to avoid double-free even when added code might cause panic. See
         // documentation of `mem::forget()` for details.

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -72,7 +72,6 @@ impl<T> Userdata<T> {
     /// Use [`UserdataSentinel::as_ptr()`] to get the pointer from the sentinel.
     ///
     /// [`prepare()`]: Self::prepare
-    /// [`sentinel()`]: Self::sentinel
     pub fn prepare_sentinel(userdata: T) -> UserdataSentinel<T> {
         let data = Self::prepare(userdata);
         UserdataSentinel(data, PhantomData)
@@ -111,7 +110,6 @@ impl<T> Userdata<T> {
     ///
     /// [`prepare()`]: Self::prepare
     /// [`consume()`]: Self::consume
-    /// [`sentinel()`]: Self::sentinel
     #[must_use]
     pub unsafe fn consume(data: *mut c_void) -> T {
         let ptr: *mut T = data.cast::<T>();


### PR DESCRIPTION
## Description

This fixes some lints that now trigger with Rust [1.87](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/).