### PR TITLE
Use native raw pointer syntax

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Rust toolchain
         # Use specific Rust version that is the minimum supported `rust-version`
         # (MSRV) from `Cargo.toml`.
-        uses: dtolnay/rust-toolchain@1.81
+        uses: dtolnay/rust-toolchain@1.82
 
       - name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   attribute ID other than `ua::AttributeId::EVENTNOTIFIER`.
 - Breaking: Replace `time::OffsetDateTime` with `time::UtcDateTime` in conversions from/to
   `ua::DateTime`.
-- Breaking: Bump Minimum Supported Rust Version (MSRV) to 1.81.
+- Breaking: Bump Minimum Supported Rust Version (MSRV) to 1.82.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ name = "open62541"
 version = "0.8.5"
 authors = ["HMI Project"]
 edition = "2021"
-# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.81 for the following reason:
-# we want to use the `expect` lint level and lint reasons, as in `#[expect(lint, reason = "...")]`.
-rust-version = "1.81"
+# Keep the MSRV number here in sync with `test.yaml`. We require Rust 1.82 for the following reason:
+# we want to use `&raw const` and `&raw mut` for creating pointers.
+rust-version = "1.82"
 description = "High-level, safe bindings for the C99 library open62541, an open source and free implementation of OPC UA (OPC Unified Architecture)."
 documentation = "https://docs.rs/open62541"
 readme = "README.md"

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::c_void,
-    ptr, slice,
+    slice,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -606,7 +606,7 @@ async fn service_request<R: ServiceRequest>(
             Some(callback_c::<R>),
             R::Response::data_type(),
             Cb::<R>::prepare(callback),
-            ptr::addr_of_mut!(request_id),
+            &raw mut request_id,
         )
     });
     // The request itself fails when the client is not connected (or the secure session has not been

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -378,7 +378,7 @@ macro_rules! data_type {
                 // in it, no matter how deeply nested.
                 unsafe {
                     open62541_sys::UA_clear(
-                        std::ptr::addr_of_mut!(self.0).cast::<std::ffi::c_void>(),
+                        (&raw mut self.0).cast::<std::ffi::c_void>(),
                         <Self as $crate::DataType>::data_type(),
                     )
                 }
@@ -393,11 +393,7 @@ macro_rules! data_type {
             fn data_type() -> *const open62541_sys::UA_DataType {
                 // PANIC: Value must fit into `usize` to allow indexing.
                 let index = usize::try_from(open62541_sys::$index).unwrap();
-                // SAFETY: We use this static variable only read-only.
-                #[expect(clippy::allow_attributes, reason = "non-static condition")]
-                #[allow(unused_unsafe, reason = "unsafe only before Rust 1.82")]
-                // This was unsafe only before Rust 1.82.
-                let ua_types = unsafe { std::ptr::addr_of!(open62541_sys::UA_TYPES) };
+                let ua_types = &raw const open62541_sys::UA_TYPES;
                 // SAFETY: Pointer is non-zero, aligned, correct type.
                 // PANIC: The given index is valid within `UA_TYPES`.
                 unsafe { (*ua_types).get(index) }.unwrap()
@@ -413,7 +409,7 @@ macro_rules! data_type {
                 let this = std::mem::ManuallyDrop::new(self);
                 // SAFETY: Aliasing memory temporarily is safe because destructor will not be
                 // called.
-                unsafe { std::ptr::read(std::ptr::addr_of!(this.0)) }
+                unsafe { std::ptr::read(&raw const this.0) }
             }
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -388,7 +388,7 @@ impl Server {
                 // changed and it is only used in the scope of the function. This means ownership is
                 // preserved and passing by value is safe here.
                 DataType::to_raw_copy(namespace_uri),
-                ptr::addr_of_mut!(found_index),
+                &raw mut found_index,
             )
         });
         if !status_code.is_good() {

--- a/src/ua/certificate_verification.rs
+++ b/src/ua/certificate_verification.rs
@@ -117,7 +117,7 @@ impl CertificateVerification {
         // documentation of `mem::forget()` for details.
         let this = ManuallyDrop::new(self);
         // SAFETY: Aliasing memory temporarily is safe because destructor will not be called.
-        unsafe { ptr::read(ptr::addr_of!(this.0)) }
+        unsafe { ptr::read(&raw const this.0) }
     }
 
     /// Creates wrapper initialized with defaults.
@@ -171,7 +171,7 @@ impl CertificateVerification {
     /// may happen when `open62541` functions are called that take ownership of values by pointer.
     #[must_use]
     pub(crate) unsafe fn as_mut_ptr(&mut self) -> *mut UA_CertificateVerification {
-        ptr::addr_of_mut!(self.0)
+        &raw mut self.0
     }
 }
 
@@ -179,7 +179,7 @@ impl Drop for CertificateVerification {
     fn drop(&mut self) {
         if let Some(clear) = self.0.clear {
             unsafe {
-                clear(ptr::addr_of_mut!(self.0));
+                clear(&raw mut self.0);
             }
         }
     }

--- a/src/ua/client.rs
+++ b/src/ua/client.rs
@@ -1,4 +1,4 @@
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 
 use open62541_sys::{
     UA_Client, UA_Client_delete, UA_Client_disconnect, UA_Client_getContext, UA_Client_getState,
@@ -42,7 +42,7 @@ impl Client {
     /// (e.g. logging configuration and logger instance).
     pub(crate) fn new_with_config(config: ua::ClientConfig) -> Self {
         let config = config.into_raw();
-        let inner = unsafe { UA_Client_newWithConfig(ptr::addr_of!(config)) };
+        let inner = unsafe { UA_Client_newWithConfig(&raw const config) };
         // PANIC: The only possible errors here are out-of-memory.
         let inner = NonNull::new(inner).expect("create UA_Client");
         Self(inner)

--- a/src/ua/server.rs
+++ b/src/ua/server.rs
@@ -1,4 +1,4 @@
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 
 use open62541_sys::{UA_Server, UA_Server_delete, UA_Server_newWithConfig};
 
@@ -26,7 +26,7 @@ impl Server {
     /// (e.g. logging configuration and logger instance).
     pub(crate) fn new_with_config(config: ua::ServerConfig) -> Self {
         let mut config = config.into_raw();
-        let inner = unsafe { UA_Server_newWithConfig(ptr::addr_of_mut!(config)) };
+        let inner = unsafe { UA_Server_newWithConfig(&raw mut config) };
         // PANIC: The only possible errors here are out-of-memory.
         let inner = NonNull::new(inner).expect("create UA_Server");
         Self(inner)


### PR DESCRIPTION
## Description

This bumps our MSRV to Rust [1.82](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/) which was released seven months ago in October 2024. This allows us to drop macro invocations `ptr::addr_of!()` and `ptr::addr_of_mut!()` in favour of `&raw const` and `&raw mut`.