### PR TITLE
Improve type safety of monitored items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add `MonitoredItemBuilder::attribute()` to select monitored attribute at compile time, yielding
-  values of the expected type.
+  values of the expected `DataValue` subtype.
 - Add `MonitoredItemValue` enum wrapping both data change and event monitored item notifications.
 
 ### Changed

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
-use open62541::{ua, AsyncClient, AsyncSubscription};
+use open62541::{ua, AsyncClient, AsyncSubscription, DataValue};
 use open62541_sys::{
     UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME,
 };
@@ -71,7 +71,7 @@ async fn monitor_background(
         let node_id = node_id.clone();
         async move {
             while let Some(value) = monitored_item.next().await {
-                let value = value.value().map(ua::Variant::to_value);
+                let value = value.as_ref().map(DataValue::value);
                 println!("Received value from node {node_id}: {value:?}");
             }
             Ok::<(), anyhow::Error>(())

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -475,8 +475,6 @@ pub trait MonitoredItemKind: sealed::MonitoredItemKind + Send + Sync + 'static {
 pub struct DataChange<T: Attribute>(PhantomData<T>);
 
 impl<T: DataChangeAttribute + Send + Sync + 'static> MonitoredItemKind for DataChange<T> {
-    // TODO: Use more specific type. Return appropriate value for attribute `T`, but still allow
-    // access to other data from `DataValue` such as timestamps.
     type Value = Result<DataValue<T::Value>>;
 
     fn map_value(value: MonitoredItemValue) -> Self::Value {

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -340,23 +340,36 @@ pub enum MonitoredItemValue {
     /// Data change payload.
     ///
     /// This is emitted for attribute IDs other than [`ua::AttributeId::EVENTNOTIFIER`].
+    #[doc(hidden)]
     DataChange { value: ua::DataValue },
 
     /// Event payload.
     ///
     /// This is emitted for attribute ID [`ua::AttributeId::EVENTNOTIFIER`].
+    #[doc(hidden)]
     Event { fields: ua::Array<ua::Variant> },
 }
 
 impl MonitoredItemValue {
-    /// Shortcut for accessing data change value.
+    /// Gets data change payload.
     ///
     /// This returns `None` for [`MonitoredItemValue::Event`].
     #[must_use]
-    pub fn value(&self) -> Option<&ua::Variant> {
+    pub const fn value(&self) -> Option<&ua::DataValue> {
         match self {
-            MonitoredItemValue::DataChange { value } => value.value(),
+            MonitoredItemValue::DataChange { value } => Some(value),
             MonitoredItemValue::Event { fields: _ } => None,
+        }
+    }
+
+    /// Gets event payload.
+    ///
+    /// This returns `None` for [`MonitoredItemValue::DataChange`].
+    #[must_use]
+    pub const fn fields(&self) -> Option<&[ua::Variant]> {
+        match self {
+            MonitoredItemValue::DataChange { value: _ } => None,
+            MonitoredItemValue::Event { fields } => Some(fields.as_slice()),
         }
     }
 }

--- a/src/async_monitored_item/create_monitored_items.rs
+++ b/src/async_monitored_item/create_monitored_items.rs
@@ -51,7 +51,7 @@ pub(super) async fn call(
 
     for item_to_create in items_to_create {
         // TODO: Think about appropriate buffer size or let the caller decide.
-        let (st_tx, st_rx) = mpsc::channel::<MonitoredItemValue>(MONITORED_ITEM_BUFFER_SIZE);
+        let (st_tx, st_rx) = mpsc::channel(MONITORED_ITEM_BUFFER_SIZE);
 
         // `open62541` requires one set of notification/delete callback and context per monitored
         // item in the request.
@@ -171,7 +171,7 @@ unsafe extern "C" fn data_change_notification_callback_c(
 
     // SAFETY: `mon_context` is result of `St::prepare()` and is used only before `delete()`.
     unsafe {
-        St::notify(mon_context, MonitoredItemValue::DataChange { value });
+        St::notify(mon_context, MonitoredItemValue::data_change(value));
     }
 }
 
@@ -202,7 +202,7 @@ unsafe extern "C" fn event_notification_callback_c(
 
     // SAFETY: `mon_context` is result of `St::prepare()` and is used only before `delete()`.
     unsafe {
-        St::notify(mon_context, MonitoredItemValue::Event { fields });
+        St::notify(mon_context, MonitoredItemValue::event(fields));
     }
 }
 

--- a/src/ua/data_types/monitored_item_create_request.rs
+++ b/src/ua/data_types/monitored_item_create_request.rs
@@ -25,13 +25,7 @@ impl MonitoredItemCreateRequest {
 
     /// Shortcut for setting attribute ID.
     ///
-    /// By default, monitored items emit [`MonitoredItemValue::DataChange`]. If the attribute ID is
-    /// set to [`ua::AttributeId::EVENTNOTIFIER`], they emit [`MonitoredItemValue::Event`] instead.
-    ///
     /// See [`ua::ReadValueId::with_attribute_id()`].
-    ///
-    /// [`MonitoredItemValue::DataChange`]: crate::MonitoredItemValue::DataChange
-    /// [`MonitoredItemValue::Event`]: crate::MonitoredItemValue::Event
     #[must_use]
     pub fn with_attribute_id(mut self, attribute_id: &ua::AttributeId) -> Self {
         self.0.itemToMonitor.attributeId = attribute_id.as_u32();


### PR DESCRIPTION
## Description

As hinted at in https://github.com/HMIProject/open62541/pull/225#discussion_r2092754179, this changes the yielded values of monitored items to the appropriately typed subtype of `DataValue`, e.g. `Variant` for `VALUE_T`, `QualifiedName` for `BROWSENAME_T` etc.