### PR TITLE
Remove deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Breaking: When using `MonitoredItemBuilder::attribute_id()` for attributes not known at compile
   time, monitored items yield values of `MonitoredItemValue`.
-- Breaking: Replace `time::OffsetDateTime` with `time::UtcDateTime` in conversions from/to
+- Breaking: Replace `time::OffsetDateTime` with `time::UtcDateTime` in conversions from and/or to
   `ua::DateTime`.
+- Breaking: Remove methods `ua::DataValue::status_code()` and `ua::DataValue::with_status_code()`
+  deprecated in 0.7.1. Use `status()` and/or `with_status()` instead.
+- Breaking: Remove method `ua::String::as_slice()` deprecated in 0.5.0. Use `as_bytes()` instead.
 - Breaking: Bump Minimum Supported Rust Version (MSRV) to 1.82.
+- Mark `AsyncMonitoredItem::into_stream()` as deprecated. Use the `Stream` implementation of this
+  type directly instead.
 
 ### Fixed
 

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -58,12 +58,6 @@ impl DataValue {
         self
     }
 
-    #[deprecated = "Use Self::with_status() instead."]
-    #[must_use]
-    pub fn with_status_code(self, status_code: &ua::StatusCode) -> Self {
-        self.with_status(status_code)
-    }
-
     /// Gets value.
     ///
     /// This returns the value as [`ua::Variant`] if it is set. Returns `None` when the `DataValue`
@@ -108,12 +102,6 @@ impl DataValue {
         self.0
             .hasStatus()
             .then(|| ua::StatusCode::new(self.0.status))
-    }
-
-    #[deprecated = "Use Self::status() instead."]
-    #[must_use]
-    pub fn status_code(&self) -> Option<ua::StatusCode> {
-        self.status()
     }
 
     pub(crate) fn to_generic<T: DataType>(&self) -> Result<crate::DataValue<T>> {

--- a/src/ua/data_types/string.rs
+++ b/src/ua/data_types/string.rs
@@ -52,12 +52,6 @@ impl String {
         matches!(self.array_value(), ArrayValue::Empty)
     }
 
-    #[deprecated(note = "use `Self::as_bytes()` instead")]
-    #[must_use]
-    pub fn as_slice(&self) -> Option<&[u8]> {
-        self.as_bytes()
-    }
-
     /// Returns string contents as byte slice.
     ///
     /// This may return [`None`] when the string itself is invalid (as defined by OPC UA).


### PR DESCRIPTION
## Description

This removes some methods that have been deprecated in 0.5.0 and 0.7.1, respectively (March 2024, December 2024). This also adds a note to an upcoming deprecation of `AsyncMonitoredItem::into_stream()` to the changelog.