### PR TITLE
Remove `unsafe` qualifier from `Server::statistics()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Bump Minimum Supported Rust Version (MSRV) to 1.83.
 - Mark `AsyncMonitoredItem::into_stream()` as deprecated. Use the `Stream` implementation of this
   type directly instead.
+- Remove `unsafe` qualifier from `Server::statistics()`, it may now be be called concurrently.
 - Upgrade to open62541 version
   [1.4.12](https://github.com/open62541/open62541/releases/tag/v1.4.12).
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -138,9 +138,7 @@ fn read_attribute(
 
 fn statistics_task(server: &Server, cancelled: &AtomicBool) {
     while !cancelled.load(Ordering::Relaxed) {
-        // SAFETY: This is not actually safe, but there is no other way to get the server
-        // statistics at the moment.
-        let statistics = unsafe { server.statistics() };
+        let statistics = server.statistics();
         println!("{statistics:?}");
         thread::sleep(Duration::from_millis(1000));
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1466,19 +1466,13 @@ impl Server {
     }
 
     /// Gets server statistics.
-    ///
-    /// # Safety
-    ///
-    /// This must only be called when no other server operations are underway, on this instance or
-    /// any of its clones (including background activity). In other words, you must have exclusive
-    /// access to the underlying server and it must not be operating.
-    //
-    // TODO: Lift this requirement when `UA_Server_getStatistics()` has been made `UA_THREADSAFE`.
-    // <https://github.com/open62541/open62541/pull/7190>
     #[must_use]
-    pub unsafe fn statistics(&self) -> ua::ServerStatistics {
+    pub fn statistics(&self) -> ua::ServerStatistics {
         unsafe {
-            ua::ServerStatistics::from_raw(UA_Server_getStatistics(self.0.as_ptr().cast_mut()))
+            ua::ServerStatistics::from_raw(UA_Server_getStatistics(
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                self.0.as_ptr().cast_mut(),
+            ))
         }
     }
 }


### PR DESCRIPTION
## Description

It is no longer necessary to treat `Server::statistics()` as `unsafe`, because the underlying function has been fixed to support concurrent access from multiple threads.