### PR TITLE
Rename `ServerRunner::run()` to match underlying function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deprecated in 0.7.1. Use `status()` and/or `with_status()` instead.
 - Breaking: Remove method `ua::String::as_slice()` deprecated in 0.5.0. Use `as_bytes()` instead.
 - Breaking: Bump Minimum Supported Rust Version (MSRV) to 1.83.
+- Rename `ServerRunner::run()` to `ServerRunner::run_until_interrupt()`. Deprecate former method.
 - Mark `AsyncMonitoredItem::into_stream()` as deprecated. Use the `Stream` implementation of this
   type directly instead.
 - Remove `unsafe` qualifier from `Server::statistics()`, it may now be be called concurrently.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -167,7 +167,7 @@ fn server_task(
 fn runner_task(runner: ServerRunner) -> anyhow::Result<()> {
     println!("Running server");
 
-    runner.run()?;
+    runner.run_until_interrupt()?;
 
     Ok(())
 }

--- a/examples/server_access_control.rs
+++ b/examples/server_access_control.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Running server");
 
-    runner.run()?;
+    runner.run_until_interrupt()?;
 
     println!("Exiting");
 

--- a/examples/server_access_control_callback.rs
+++ b/examples/server_access_control_callback.rs
@@ -107,7 +107,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Running server");
 
-    runner.run()?;
+    runner.run_until_interrupt()?;
 
     println!("Exiting");
 

--- a/examples/server_builder.rs
+++ b/examples/server_builder.rs
@@ -9,7 +9,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Running server");
 
-    runner.run()?;
+    runner.run_until_interrupt()?;
 
     println!("Exiting");
 

--- a/examples/server_data_source.rs
+++ b/examples/server_data_source.rs
@@ -102,7 +102,7 @@ fn main() -> anyhow::Result<()> {
     // Start runner task that handles incoming connections (events).
     let runner_task_handle = thread::spawn(|| -> anyhow::Result<()> {
         println!("Running server");
-        runner.run()?;
+        runner.run_until_interrupt()?;
         Ok(())
     });
 

--- a/examples/server_encryption.rs
+++ b/examples/server_encryption.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Running server");
 
-    runner.run()?;
+    runner.run_until_interrupt()?;
 
     println!("Exiting");
 

--- a/examples/server_method_callback.rs
+++ b/examples/server_method_callback.rs
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
     // Start runner task that handles incoming connections (events).
     let runner_task_handle = thread::spawn(|| -> anyhow::Result<()> {
         println!("Running server");
-        runner.run()?;
+        runner.run_until_interrupt()?;
         Ok(())
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //!
 //! // Define data nodes on `server`.
 //!
-//! runner.run()?;
+//! runner.run_until_interrupt()?;
 //! #
 //! # Ok(())
 //! # }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1495,6 +1495,16 @@ impl ServerRunner {
         }
     }
 
+    /// Runs the server.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the server cannot be started.
+    #[deprecated = "Use `Self::run_until_interrupt()` instead."]
+    pub fn run(self) -> Result<()> {
+        self.run_until_interrupt()
+    }
+
     /// Runs the server until interrupted.
     ///
     /// The server is shut down cleanly upon receiving the `SIGINT` signal at which point the method
@@ -1503,7 +1513,7 @@ impl ServerRunner {
     /// # Errors
     ///
     /// This fails when the server cannot be started.
-    pub fn run(self) -> Result<()> {
+    pub fn run_until_interrupt(self) -> Result<()> {
         let Self {
             server,
             access_control_sentinel,


### PR DESCRIPTION
## Description

This renames `ServerRunner::run()` to `ServerRunner::run_until_interrupt()` in order to match the underlying library function. The former method is marked as deprecated to be removed in a future breaking release.