### PR TITLE
Refactor use of typed `DataValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Implement `std::hash::Hash` for `ua::QualifiedName`.
 - Add method `ua::DataValue::cast()` to create typed `DataValue` instance that returns appropriate
   value type with `DataValue::value()`, `DataValue::into_value()`.
+- Add method `DataValue::status()` to fetch underlying status code like `ua::DataValue::status()`.
 
 ### Changed
 
@@ -21,6 +22,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `server_picoseconds()` of `DataValue` are no longer `const`.
 - Breaking: `AsyncClient::read_attributes()`, `AsyncClient::read_many_attributes()` return only an
   outer error, not nested errors. Use `DataValue` methods to check validity or status of value(s).
+- Breaking: `Server::read_attribute()` always returns `DataValue` (without error). Use `DataValue`
+  methods to check validity or status of value.
 
 ## [0.9.0] - 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Implement `std::hash::Hash` for `ua::QualifiedName`.
 - Add method `ua::DataValue::cast()` to create typed `DataValue` instance that returns appropriate
-  value type with `DataValue::value()`, `DataValue::into_value()`.
+  value type with `DataValue::scalar_value()`, `DataValue::into_scalar_value()`.
 - Add method `DataValue::status()` to fetch underlying status code like `ua::DataValue::status()`.
 
 ### Changed
 
-- Breaking: Return error from `DataValue::value()`, ``DataValue::into_value()` when value is unset
-  or cast fails.
-- Breaking: Methods `value()`, `source_timestamp()`, `server_timestamp()`, `source_picoseconds()`,
-  `server_picoseconds()` of `DataValue` are no longer `const`.
+- Breaking: Return error from `DataValue::scalar_value()`, `DataValue::into_scalar_value()` if the
+  value is unset or the cast fails.
 - Breaking: `AsyncClient::read_attributes()`, `AsyncClient::read_many_attributes()` return only an
   outer error, not nested errors. Use `DataValue` methods to check validity or status of value(s).
 - Breaking: `Server::read_attribute()` always returns `DataValue` (without error). Use `DataValue`
   methods to check validity or status of value.
+- Rename `DataValue` methods `value()`, `into_value()` to `scalar_value()`, `into_scalar_value()`,
+  marking previous names as deprecated.
 
 ## [0.9.0] - 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
 - Implement `std::hash::Hash` for `ua::QualifiedName`.
+- Add method `ua::DataValue::cast()` to create typed `DataValue` instance that returns appropriate
+  value type with `DataValue::value()`, `DataValue::into_value()`.
+
+### Changed
+
+- Breaking: Return error from `DataValue::value()`, ``DataValue::into_value()` when value is unset
+  or cast fails.
+- Breaking: Methods `value()`, `source_timestamp()`, `server_timestamp()`, `source_picoseconds()`,
+  `server_picoseconds()` of `DataValue` are no longer `const`.
 
 ## [0.9.0] - 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or cast fails.
 - Breaking: Methods `value()`, `source_timestamp()`, `server_timestamp()`, `source_picoseconds()`,
   `server_picoseconds()` of `DataValue` are no longer `const`.
+- Breaking: `AsyncClient::read_attributes()`, `AsyncClient::read_many_attributes()` return only an
+  outer error, not nested errors. Use `DataValue` methods to check validity or status of value(s).
 
 ## [0.9.0] - 2025-06-02
 

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -207,7 +207,7 @@ fn get_arguments(value: &DataValue<ua::Variant>) -> anyhow::Result<Vec<(ua::Stri
     // `Argument` type.
 
     let arguments = value
-        .value()
+        .scalar_value()
         .context("should have value")?
         .to_array::<ua::Argument>()
         .context("should have array")?;

--- a/examples/async_call.rs
+++ b/examples/async_call.rs
@@ -188,7 +188,7 @@ async fn read_sparse_node_values(
 
     for node_id in node_ids {
         match node_id {
-            Some(_) => result.push(Some(values.next().expect("should have value")?)),
+            Some(_) => result.push(Some(values.next().expect("should have value"))),
             None => result.push(None),
         }
     }
@@ -208,8 +208,9 @@ fn get_arguments(value: &DataValue<ua::Variant>) -> anyhow::Result<Vec<(ua::Stri
 
     let arguments = value
         .value()
+        .context("should have value")?
         .to_array::<ua::Argument>()
-        .ok_or(anyhow::anyhow!("should have array"))?;
+        .context("should have array")?;
 
     Ok(arguments
         .iter()

--- a/examples/async_concurrent.rs
+++ b/examples/async_concurrent.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
                 .read_value(&ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME))
                 .await
                 .context("read")?;
-            let value = value.value().context("value")?.to_value();
+            let value = value.scalar_value().context("value")?.to_value();
             println!("Value: {value:?}");
 
             Ok::<_, anyhow::Error>(())

--- a/examples/async_concurrent.rs
+++ b/examples/async_concurrent.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
                 .read_value(&ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME))
                 .await
                 .context("read")?;
-            let value = value.value().to_value();
+            let value = value.value().context("value")?.to_value();
             println!("Value: {value:?}");
 
             Ok::<_, anyhow::Error>(())

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -71,7 +71,7 @@ async fn monitor_background(
         let node_id = node_id.clone();
         async move {
             while let Some(value) = monitored_item.next().await {
-                let value = value.value();
+                let value = value.scalar_value();
                 println!("Received value from node {node_id}: {value:?}");
             }
             Ok::<(), anyhow::Error>(())

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
-use open62541::{ua, AsyncClient, AsyncSubscription, DataValue};
+use open62541::{ua, AsyncClient, AsyncSubscription};
 use open62541_sys::{
     UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME,
 };
@@ -71,7 +71,7 @@ async fn monitor_background(
         let node_id = node_id.clone();
         async move {
             while let Some(value) = monitored_item.next().await {
-                let value = value.as_ref().map(DataValue::value);
+                let value = value.value();
                 println!("Received value from node {node_id}: {value:?}");
             }
             Ok::<(), anyhow::Error>(())

--- a/examples/async_read_write.rs
+++ b/examples/async_read_write.rs
@@ -50,10 +50,7 @@ async fn read_attributes(client: &AsyncClient, node_id: &ua::NodeId) -> anyhow::
     let attribute_values = client.read_attributes(node_id, &ATTRIBUTE_IDS).await?;
 
     for (attribute_id, value) in ATTRIBUTE_IDS.iter().zip(attribute_values.iter()) {
-        match value {
-            Ok(value) => println!("- {attribute_id} -> {value:?}"),
-            Err(err) => println!("- {attribute_id} -> {err}"),
-        }
+        println!("- {attribute_id} -> {value:?}");
     }
 
     Ok(())

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -2,7 +2,7 @@ use std::{pin::pin, sync::Arc};
 
 use anyhow::Context as _;
 use futures::StreamExt as _;
-use open62541::{ua, AsyncClient, DataValue};
+use open62541::{ua, AsyncClient};
 use open62541_sys::UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME;
 use tokio::task;
 
@@ -38,7 +38,11 @@ async fn read_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
 
     println!(
         "Node {node_id} has value {:?}",
-        value.value().as_scalar().and_then(ua::DateTime::to_utc)
+        value
+            .value()
+            .context("get value")?
+            .as_scalar()
+            .and_then(ua::DateTime::to_utc)
     );
 
     Ok(())
@@ -61,9 +65,9 @@ async fn watch_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
 
     while let Some((index, value)) = stream.next().await {
         let value = value
-            .as_ref()
-            .map(DataValue::value)
+            .value()
             .ok()
+            .as_ref()
             .and_then(ua::Variant::as_scalar)
             .and_then(ua::DateTime::to_utc);
         println!("Node {node_id} emitted value #{index}: {value:?}");

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -67,7 +67,6 @@ async fn watch_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
         let value = value
             .value()
             .ok()
-            .as_ref()
             .and_then(ua::Variant::as_scalar)
             .and_then(ua::DateTime::to_utc);
         println!("Node {node_id} emitted value #{index}: {value:?}");

--- a/examples/async_send_sync.rs
+++ b/examples/async_send_sync.rs
@@ -39,7 +39,7 @@ async fn read_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
     println!(
         "Node {node_id} has value {:?}",
         value
-            .value()
+            .scalar_value()
             .context("get value")?
             .as_scalar()
             .and_then(ua::DateTime::to_utc)
@@ -65,7 +65,7 @@ async fn watch_background(client: Arc<AsyncClient>) -> anyhow::Result<()> {
 
     while let Some((index, value)) = stream.next().await {
         let value = value
-            .value()
+            .scalar_value()
             .ok()
             .and_then(ua::Variant::as_scalar)
             .and_then(ua::DateTime::to_utc);

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -47,13 +47,13 @@ fn main() -> anyhow::Result<()> {
         &ua::Variant::scalar(ua::String::new("foobar")?),
     )?;
 
-    read_attribute(&server, &value_node_id, ua::AttributeId::NODEID_T)?;
-    read_attribute(&server, &value_node_id, ua::AttributeId::NODECLASS_T)?;
-    read_attribute(&server, &value_node_id, ua::AttributeId::BROWSENAME_T)?;
-    read_attribute(&server, &value_node_id, ua::AttributeId::DISPLAYNAME_T)?;
+    read_attribute(&server, &value_node_id, ua::AttributeId::NODEID_T);
+    read_attribute(&server, &value_node_id, ua::AttributeId::NODECLASS_T);
+    read_attribute(&server, &value_node_id, ua::AttributeId::BROWSENAME_T);
+    read_attribute(&server, &value_node_id, ua::AttributeId::DISPLAYNAME_T);
 
     for attribute in [ua::AttributeId::DESCRIPTION, ua::AttributeId::WRITEMASK] {
-        read_attribute(&server, &value_node_id, &attribute)?;
+        read_attribute(&server, &value_node_id, &attribute);
     }
 
     println!("Adding server data value nodes");
@@ -76,8 +76,8 @@ fn main() -> anyhow::Result<()> {
             .with_source_timestamp(&utc_datetime!(2024-02-09 12:34:56).try_into()?),
     )?;
 
-    read_attribute(&server, &data_value_node_id, ua::AttributeId::NODEID_T)?;
-    read_attribute(&server, &data_value_node_id, &ua::AttributeId::VALUE)?;
+    read_attribute(&server, &data_value_node_id, ua::AttributeId::NODEID_T);
+    read_attribute(&server, &data_value_node_id, &ua::AttributeId::VALUE);
 
     let cancelled = Arc::new(AtomicBool::new(false));
 
@@ -124,16 +124,10 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn read_attribute(
-    server: &Server,
-    node_id: &ua::NodeId,
-    attribute: impl Attribute,
-) -> anyhow::Result<()> {
+fn read_attribute(server: &Server, node_id: &ua::NodeId, attribute: impl Attribute) {
     let value = server.read_attribute(node_id, attribute);
 
     println!("- attribute {attribute:?} has value {value:?}");
-
-    Ok(())
 }
 
 fn statistics_task(server: &Server, cancelled: &AtomicBool) {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -129,7 +129,7 @@ fn read_attribute(
     node_id: &ua::NodeId,
     attribute: impl Attribute,
 ) -> anyhow::Result<()> {
-    let value = server.read_attribute(node_id, attribute)?;
+    let value = server.read_attribute(node_id, attribute);
 
     println!("- attribute {attribute:?} has value {value:?}");
 

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -75,7 +75,7 @@ impl<K: MonitoredItemKind> MonitoredItemBuilder<K> {
     ///
     /// if let Some(value) = monitored_item.next().await {
     ///     // Typed value for attribute `BROWSENAME` above.
-    ///     let value: DataValue<ua::QualifiedName> = value?;
+    ///     let value: DataValue<ua::QualifiedName> = value;
     /// }
     /// # Ok(())
     /// # }

--- a/src/async_monitored_item.rs
+++ b/src/async_monitored_item.rs
@@ -475,11 +475,11 @@ pub trait MonitoredItemKind: sealed::MonitoredItemKind + Send + Sync + 'static {
 pub struct DataChange<T: Attribute>(PhantomData<T>);
 
 impl<T: DataChangeAttribute + Send + Sync + 'static> MonitoredItemKind for DataChange<T> {
-    type Value = Result<DataValue<T::Value>>;
+    type Value = DataValue<T::Value>;
 
     fn map_value(value: MonitoredItemValue) -> Self::Value {
         match value.into_inner() {
-            MonitoredItemValueInner::DataChange { value } => value.to_generic(),
+            MonitoredItemValueInner::DataChange { value } => value.cast(),
             MonitoredItemValueInner::Event { fields: _ } => {
                 // PANIC: Typestate uses attribute ID to enforce callback method.
                 unreachable!("unexpected event payload in data change notification");

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::{c_void, CStr},
     fmt::Debug,
-    mem::MaybeUninit,
+    mem::{self, MaybeUninit},
     ptr,
 };
 
@@ -59,10 +59,12 @@ pub unsafe trait DataType: Debug + Clone {
     ///
     /// Ownership of the value passes to `Self`. This must only be used for values that are not
     /// contained within other values that may be dropped (such as attributes in other data types).
-    /// In this case use [`clone_raw()`] instead to clone data instead of taking ownership.
+    /// In this case use [`clone_raw()`] or [`move_raw()`] instead to clone or move data instead of
+    /// taking ownership.
     ///
     /// [`UA_new()`]: open62541_sys::UA_new
     /// [`clone_raw()`]: DataType::clone_raw
+    /// [`move_raw()`]: DataType::move_raw
     #[must_use]
     unsafe fn from_raw(src: Self::Inner) -> Self;
 
@@ -150,6 +152,19 @@ pub unsafe trait DataType: Debug + Clone {
         let dst = unsafe { dst.assume_init() };
         // SAFETY: We pass a value without pointers to it into `Self`.
         unsafe { Self::from_raw(dst) }
+    }
+
+    /// Creates wrapper by moving value from `src`.
+    ///
+    /// This moves an existing value and uses [`UA_init()`] to leave an initialized value behind.
+    #[must_use]
+    fn move_raw(src: &mut Self::Inner) -> Self {
+        // Take out source value and leave behind a freshly initialized value that gets cleaned up
+        // when the external owner frees memory.
+        let src = mem::replace(src, Self::init().into_raw());
+        // SAFETY: We have replaced the original source with a freshly initialized value. There is
+        // no other owner and we take ownership.
+        unsafe { Self::from_raw(src) }
     }
 
     /// Clones value into `dst`.

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -59,12 +59,12 @@ pub unsafe trait DataType: Debug + Clone {
     ///
     /// Ownership of the value passes to `Self`. This must only be used for values that are not
     /// contained within other values that may be dropped (such as attributes in other data types).
-    /// In this case use [`clone_raw()`] or [`move_raw()`] instead to clone or move data instead of
+    /// In this case use [`clone_raw()`] or [`take_raw()`] instead to clone or move data instead of
     /// taking ownership.
     ///
     /// [`UA_new()`]: open62541_sys::UA_new
     /// [`clone_raw()`]: DataType::clone_raw
-    /// [`move_raw()`]: DataType::move_raw
+    /// [`take_raw()`]: DataType::take_raw
     #[must_use]
     unsafe fn from_raw(src: Self::Inner) -> Self;
 
@@ -158,7 +158,7 @@ pub unsafe trait DataType: Debug + Clone {
     ///
     /// This moves an existing value and uses [`UA_init()`] to leave an initialized value behind.
     #[must_use]
-    fn move_raw(src: &mut Self::Inner) -> Self {
+    fn take_raw(src: &mut Self::Inner) -> Self {
         // Take out source value and leave behind a freshly initialized value that gets cleaned up
         // when the external owner frees memory.
         let src = mem::replace(src, Self::init().into_raw());

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -63,6 +63,11 @@ impl<T: DataType> DataValue<T> {
     pub fn server_picoseconds(&self) -> Option<u16> {
         self.data_value.server_picoseconds()
     }
+
+    #[must_use]
+    pub fn status(&self) -> Option<ua::StatusCode> {
+        self.data_value.status()
+    }
 }
 
 impl DataValue<ua::Variant> {

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -11,23 +11,31 @@ pub struct DataValue<T> {
 
 impl<T: DataType> DataValue<T> {
     #[must_use]
-    pub(crate) fn new(data_value: ua::DataValue) -> Self {
+    pub(crate) const fn new(data_value: ua::DataValue) -> Self {
         Self {
             data_value,
             _kind: PhantomData,
         }
     }
 
-    #[must_use]
-    pub fn value(&self) -> Result<T> {
+    /// Gets scalar value.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the value is unset or not a scalar of the expected type.
+    pub fn value(&self) -> Result<&T> {
         self.data_value
             .value()
             .ok_or(Error::internal("missing value"))?
-            .to_scalar::<T>()
+            .as_scalar::<T>()
             .ok_or(Error::internal("unexpected data type"))
     }
 
-    #[must_use]
+    /// Extracts scalar value.
+    ///
+    /// # Errors
+    ///
+    /// This fails when the value is unset or not a scalar of the expected type.
     pub fn into_value(self) -> Result<T> {
         self.data_value
             .into_value()

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -1,94 +1,75 @@
+use std::marker::PhantomData;
+
 use crate::{ua, DataType, Error, Result};
 
 /// Typed variant of [`ua::DataValue`].
 #[derive(Debug, Clone)]
 pub struct DataValue<T> {
-    value: T,
-    source_timestamp: Option<ua::DateTime>,
-    server_timestamp: Option<ua::DateTime>,
-    source_picoseconds: Option<u16>,
-    server_picoseconds: Option<u16>,
+    data_value: ua::DataValue,
+    _kind: PhantomData<T>,
 }
 
 impl<T: DataType> DataValue<T> {
-    pub(crate) fn new(data_value: &ua::DataValue) -> Result<Self> {
-        // Verify that data value is valid before accessing value. The OPC UA specification requires
-        // us to do so. The status code may be omitted, in which case it is treated as valid data.
-        Error::verify_good(&data_value.status().unwrap_or(ua::StatusCode::GOOD))?;
+    #[must_use]
+    pub(crate) fn new(data_value: ua::DataValue) -> Self {
+        Self {
+            data_value,
+            _kind: PhantomData,
+        }
+    }
 
-        // When the status code indicates a good data value, the value is expected to be set.
-        let value = data_value
+    #[must_use]
+    pub fn value(&self) -> Result<T> {
+        self.data_value
             .value()
-            .ok_or(Error::Internal("missing value"))?
+            .ok_or(Error::internal("missing value"))?
             .to_scalar::<T>()
-            .ok_or(Error::internal("unexpected data type"))?;
-
-        Ok(Self {
-            value,
-            source_timestamp: data_value.source_timestamp().cloned(),
-            server_timestamp: data_value.server_timestamp().cloned(),
-            source_picoseconds: data_value.source_picoseconds(),
-            server_picoseconds: data_value.server_picoseconds(),
-        })
+            .ok_or(Error::internal("unexpected data type"))
     }
 
     #[must_use]
-    pub const fn value(&self) -> &T {
-        &self.value
+    pub fn into_value(self) -> Result<T> {
+        self.data_value
+            .into_value()
+            .ok_or(Error::internal("missing value"))?
+            .into_scalar::<T>()
+            .ok_or(Error::internal("unexpected data type"))
     }
 
     #[must_use]
-    pub fn into_value(self) -> T {
-        self.value
+    pub fn source_timestamp(&self) -> Option<&ua::DateTime> {
+        self.data_value.source_timestamp()
     }
 
     #[must_use]
-    pub const fn source_timestamp(&self) -> Option<&ua::DateTime> {
-        self.source_timestamp.as_ref()
+    pub fn server_timestamp(&self) -> Option<&ua::DateTime> {
+        self.data_value.server_timestamp()
     }
 
     #[must_use]
-    pub const fn server_timestamp(&self) -> Option<&ua::DateTime> {
-        self.server_timestamp.as_ref()
+    pub fn source_picoseconds(&self) -> Option<u16> {
+        self.data_value.source_picoseconds()
     }
 
     #[must_use]
-    pub const fn source_picoseconds(&self) -> Option<u16> {
-        self.source_picoseconds
-    }
-
-    #[must_use]
-    pub const fn server_picoseconds(&self) -> Option<u16> {
-        self.server_picoseconds
+    pub fn server_picoseconds(&self) -> Option<u16> {
+        self.data_value.server_picoseconds()
     }
 }
 
 impl DataValue<ua::Variant> {
-    /// Cast to specific value type.
+    /// Casts to specific value type.
     ///
-    /// This consumes `self` and casts the inner value to the specified data type. This should be
-    /// used in situation where the expected type can be deduced from circumstances and unwrapped
-    /// data values are needed for convenience. This always expects a scalar value.
+    /// This adjusts the target type of `self`, casting the inner value to the specified data type
+    /// when read with [`Self::value()`]. This should be used in situations when the expected type
+    /// can be deduced from circumstances and typed data values can be returned for convenience.
     #[cfg_attr(not(feature = "tokio"), expect(dead_code, reason = "unused"))]
-    pub(crate) fn into_scalar<T: DataType>(self) -> Result<DataValue<T>> {
-        let Self {
-            value,
-            source_timestamp,
-            server_timestamp,
-            source_picoseconds,
-            server_picoseconds,
-        } = self;
+    pub(crate) fn cast<T: DataType>(self) -> DataValue<T> {
+        let Self { data_value, _kind } = self;
 
-        let value = value
-            .to_scalar::<T>()
-            .ok_or(Error::internal("unexpected data type"))?;
-
-        Ok(DataValue {
-            value,
-            source_timestamp,
-            server_timestamp,
-            source_picoseconds,
-            server_picoseconds,
-        })
+        DataValue {
+            data_value,
+            _kind: PhantomData,
+        }
     }
 }

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -18,12 +18,18 @@ impl<T: DataType> DataValue<T> {
         }
     }
 
+    #[expect(clippy::missing_errors_doc, reason = "deprecated method")]
+    #[deprecated = "Use `Self::scalar_value()` instead."]
+    pub fn value(&self) -> Result<&T> {
+        self.scalar_value()
+    }
+
     /// Gets scalar value.
     ///
     /// # Errors
     ///
     /// This fails when the value is unset or not a scalar of the expected type.
-    pub fn value(&self) -> Result<&T> {
+    pub fn scalar_value(&self) -> Result<&T> {
         self.data_value
             .value()
             .ok_or(Error::internal("missing value"))?
@@ -31,12 +37,18 @@ impl<T: DataType> DataValue<T> {
             .ok_or(Error::internal("unexpected data type"))
     }
 
+    #[expect(clippy::missing_errors_doc, reason = "deprecated method")]
+    #[deprecated = "Use `Self::into_scalar_value()` instead."]
+    pub fn into_value(self) -> Result<T> {
+        self.into_scalar_value()
+    }
+
     /// Extracts scalar value.
     ///
     /// # Errors
     ///
     /// This fails when the value is unset or not a scalar of the expected type.
-    pub fn into_value(self) -> Result<T> {
+    pub fn into_scalar_value(self) -> Result<T> {
         self.data_value
             .into_value()
             .ok_or(Error::internal("missing value"))?

--- a/src/server.rs
+++ b/src/server.rs
@@ -1405,6 +1405,7 @@ impl Server {
         let item = ua::ReadValueId::init()
             .with_node_id(node_id)
             .with_attribute_id(&attribute.id());
+
         let result = unsafe {
             ua::DataValue::from_raw(UA_Server_read(
                 self.server.as_ptr().cast_mut(),
@@ -1414,7 +1415,8 @@ impl Server {
                 ua::TimestampsToReturn::BOTH.into_raw(),
             ))
         };
-        result.to_generic::<T::Value>()
+
+        Ok(result.cast())
     }
 
     /// Writes node value.

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -73,7 +73,7 @@ impl DataValue {
     pub(crate) fn into_value(mut self) -> Option<ua::Variant> {
         self.0
             .hasValue()
-            .then(|| DataType::move_raw(&mut self.0.value))
+            .then(|| DataType::take_raw(&mut self.0.value))
     }
 
     #[must_use]

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -1,4 +1,4 @@
-use crate::{ua, DataType, Result};
+use crate::{ua, DataType};
 
 crate::data_type!(DataValue);
 
@@ -70,6 +70,13 @@ impl DataValue {
     }
 
     #[must_use]
+    pub(crate) fn into_value(mut self) -> Option<ua::Variant> {
+        self.0
+            .hasValue()
+            .then(|| DataType::move_raw(&mut self.0.value))
+    }
+
+    #[must_use]
     pub fn source_timestamp(&self) -> Option<&ua::DateTime> {
         self.0
             .hasSourceTimestamp()
@@ -104,7 +111,15 @@ impl DataValue {
             .then(|| ua::StatusCode::new(self.0.status))
     }
 
-    pub(crate) fn to_generic<T: DataType>(&self) -> Result<crate::DataValue<T>> {
+    /// Casts to specific value type.
+    ///
+    /// This adjusts the target type of `self`, casting the inner value to the specified data type
+    /// when read with [`Self::value()`]. This should be used in situations when the expected type
+    /// can be deduced from circumstances and typed data values can be returned for convenience.
+    ///
+    /// [`Self::value()`]: crate::DataValue::value
+    #[must_use]
+    pub fn cast<T: DataType>(self) -> crate::DataValue<T> {
         crate::DataValue::new(self)
     }
 }

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -119,7 +119,7 @@ impl DataValue {
     ///
     /// [`Self::value()`]: crate::DataValue::value
     #[must_use]
-    pub fn cast<T: DataType>(self) -> crate::DataValue<T> {
+    pub const fn cast<T: DataType>(self) -> crate::DataValue<T> {
         crate::DataValue::new(self)
     }
 }

--- a/src/ua/data_types/data_value.rs
+++ b/src/ua/data_types/data_value.rs
@@ -114,8 +114,8 @@ impl DataValue {
     /// Casts to specific value type.
     ///
     /// This adjusts the target type of `self`, casting the inner value to the specified data type
-    /// when read with [`Self::value()`]. This should be used in situations when the expected type
-    /// can be deduced from circumstances and typed data values can be returned for convenience.
+    /// when read with [`Self::value()`]. Use this when the type can be deduced from circumstances
+    /// and typed data values should be returned for convenience.
     ///
     /// [`Self::value()`]: crate::DataValue::value
     #[must_use]

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -105,7 +105,7 @@ impl Variant {
         self.scalar_data::<T>()
             // SAFETY: Inner pointer holds valid data and we have exclusive access through `self`.
             .and_then(|data| unsafe { data.cast_mut().as_mut() })
-            .map(T::move_raw)
+            .map(T::take_raw)
     }
 
     #[must_use]

--- a/src/ua/data_types/variant.rs
+++ b/src/ua/data_types/variant.rs
@@ -86,18 +86,32 @@ impl Variant {
 
     #[must_use]
     pub fn as_scalar<T: DataType>(&self) -> Option<&T> {
-        self.scalar_data::<T>().map(T::raw_ref)
+        self.scalar_data::<T>()
+            // SAFETY: Inner pointer holds valid data.
+            .and_then(|data| unsafe { data.as_ref() })
+            .map(T::raw_ref)
     }
 
     #[must_use]
     pub fn to_scalar<T: DataType>(&self) -> Option<T> {
-        self.scalar_data::<T>().map(T::clone_raw)
+        self.scalar_data::<T>()
+            // SAFETY: Inner pointer holds valid data.
+            .and_then(|data| unsafe { data.as_ref() })
+            .map(T::clone_raw)
     }
 
     #[must_use]
-    fn scalar_data<T: DataType>(&self) -> Option<&T::Inner> {
+    pub(crate) fn into_scalar<T: DataType>(self) -> Option<T> {
+        self.scalar_data::<T>()
+            // SAFETY: Inner pointer holds valid data and we have exclusive access through `self`.
+            .and_then(|data| unsafe { data.cast_mut().as_mut() })
+            .map(T::move_raw)
+    }
+
+    #[must_use]
+    fn scalar_data<T: DataType>(&self) -> Option<*const T::Inner> {
         if unsafe { UA_Variant_hasScalarType(self.as_ptr(), T::data_type()) } {
-            unsafe { self.0.data.cast::<T::Inner>().as_ref() }
+            Some(self.0.data.cast::<T::Inner>())
         } else {
             if T::data_type() != Self::data_type() {
                 return None;
@@ -105,7 +119,7 @@ impl Variant {
             // If type conversion to `ua::Variant` is requested, we fall back to `self` as-is (OPC
             // UA specifies that variants cannot directly contain other variants; we use this here
             // to allow idempotent unwrapping which is useful in generic code).
-            unsafe { self.as_ptr().cast::<T::Inner>().as_ref() }
+            Some(unsafe { self.as_ptr().cast::<T::Inner>() })
         }
     }
 


### PR DESCRIPTION
## Description

This cleans up the invalid assumption that [`DataValue`](https://reference.opcfoundation.org/Core/Part4/v104/docs/7.7) only holds a value when `statusCode` has severity Good. This is not necessarily true, in particular, `DataValue` is allowed to have a value when `statusCode` is Uncertain, or even Bad.

The implication for our conversion from `ua::DataValue` to `DataValue<T>` is that we can always do the conversion without errors, but we must be prepared to deal with unset or unexpected `value` attributes later.