### PR TITLE
Update GitHub Windows runners

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -50,9 +50,9 @@ jobs:
 
     steps:
       - name: Adjust build settings for Windows
-        if: contains(matrix.target, '-windows-')
-        # Required for Windows builds: for version numbers with pre-release part
-        # as suffix, the resulting paths would get too long to build otherwise.
+        if: startsWith(matrix.runner_os, 'windows-') && !endsWith(matrix.runner_os, '-2025')
+        # Required for Windows builds on older runners: for version numbers with
+        # pre-release part as suffix, the resulting paths would become too long.
         run: >-
           echo "CARGO_TARGET_DIR=D:\t" >> $env:GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,9 +67,9 @@ jobs:
 
     steps:
       - name: Adjust build settings for Windows
-        if: contains(matrix.target, '-windows-')
-        # Required for Windows builds: for version numbers with pre-release part
-        # as suffix, the resulting paths would get too long to build otherwise.
+        if: startsWith(matrix.runner_os, 'windows-') && !endsWith(matrix.runner_os, '-2025')
+        # Required for Windows builds on older runners: for version numbers with
+        # pre-release part as suffix, the resulting paths would become too long.
         run: >-
           echo "CARGO_TARGET_DIR=D:\t" >> $env:GITHUB_ENV
 


### PR DESCRIPTION
## Description

This removes the deprecated Windows 2019 runner and adds the new Windows 2025 runner to our GitHub workflows. See [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) for details.