### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/codespell-project/codespell
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.33.0
+    rev: 0.33.2
     hooks:
       - id: check-github-actions
       - id: check-github-workflows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ get_unwrap = "warn"
 index_refutable_slice = "warn"
 indexing_slicing = "warn"
 manual_assert = "warn"
-match_on_vec_items = "warn"
 match_wild_err_arm = "warn"
 # TODO: Add assert messages.
 missing_assert_message = "allow"

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,7 +195,7 @@ impl ClientBuilder {
     pub fn accept_all(mut self) -> Self {
         let config = self.config_mut();
         unsafe {
-            UA_CertificateVerification_AcceptAll(&mut config.certificateVerification);
+            UA_CertificateVerification_AcceptAll(&raw mut config.certificateVerification);
         }
         self
     }
@@ -280,8 +280,8 @@ impl ClientBuilder {
                 UA_Client_getEndpoints(
                     client.0.as_mut_ptr(),
                     server_url.as_ptr(),
-                    &mut endpoint_descriptions_size,
-                    &mut endpoint_descriptions_ptr,
+                    &raw mut endpoint_descriptions_size,
+                    &raw mut endpoint_descriptions_ptr,
                 )
             };
             // Wrap array result immediately to not leak memory when leaving function early as with

--- a/src/server.rs
+++ b/src/server.rs
@@ -194,8 +194,8 @@ impl ServerBuilder {
     pub fn accept_all(mut self) -> Self {
         let config = self.config_mut();
         unsafe {
-            UA_CertificateVerification_AcceptAll(&mut config.secureChannelPKI);
-            UA_CertificateVerification_AcceptAll(&mut config.sessionPKI);
+            UA_CertificateVerification_AcceptAll(&raw mut config.secureChannelPKI);
+            UA_CertificateVerification_AcceptAll(&raw mut config.sessionPKI);
         }
         self
     }
@@ -1197,8 +1197,8 @@ impl Server {
                 // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
                 self.server.as_ptr().cast_mut(),
                 browse_description.as_ptr(),
-                &mut result_size,
-                &mut result_ptr,
+                &raw mut result_size,
+                &raw mut result_ptr,
             )
         });
         Error::verify_good(&status_code)?;

--- a/src/ua/client_config.rs
+++ b/src/ua/client_config.rs
@@ -224,7 +224,7 @@ impl Drop for ClientConfig {
             // Fetch context pointer before clearing config. Free associated memory only afterwards.
             let context = inner.clientContext.cast::<ClientContext>();
 
-            unsafe { UA_ClientConfig_clear(&mut inner) }
+            unsafe { UA_ClientConfig_clear(&raw mut inner) }
 
             // Reclaim wrapped client context to avoid leaking memory. This simply drops the value.
             let _context: Box<ClientContext> = unsafe { Box::from_raw(context) };

--- a/src/ua/data_types/byte_string.rs
+++ b/src/ua/data_types/byte_string.rs
@@ -29,7 +29,7 @@ impl ByteString {
         };
         // We let `UA_ByteString_copy()` do the heavy lifting of allocating memory and copying data.
         let status_code =
-            ua::StatusCode::new(unsafe { UA_ByteString_copy(&src, dst.as_mut_ptr()) });
+            ua::StatusCode::new(unsafe { UA_ByteString_copy(&raw const src, dst.as_mut_ptr()) });
         // PANIC: The only possible errors here are out-of-memory.
         assert!(
             status_code.is_good(),

--- a/src/ua/secure_channel_state.rs
+++ b/src/ua/secure_channel_state.rs
@@ -17,6 +17,6 @@ impl SecureChannelState {
     #[expect(clippy::allow_attributes, reason = "non-static condition")]
     #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_SecureChannelState {
-        &mut self.0
+        &raw mut self.0
     }
 }

--- a/src/ua/server_config.rs
+++ b/src/ua/server_config.rs
@@ -191,7 +191,7 @@ impl Drop for ServerConfig {
         // Check if we still hold the server config. If not, we need not clean up: the ownership has
         // passed to the server that was created from this config.
         if let Some(mut inner) = self.0.take() {
-            unsafe { UA_ServerConfig_clean(&mut inner) }
+            unsafe { UA_ServerConfig_clean(&raw mut inner) }
         }
     }
 }

--- a/src/ua/session_state.rs
+++ b/src/ua/session_state.rs
@@ -17,6 +17,6 @@ impl SessionState {
     #[expect(clippy::allow_attributes, reason = "non-static condition")]
     #[allow(clippy::missing_const_for_fn, reason = "unsupported before Rust 1.87")]
     pub(crate) fn as_mut_ptr(&mut self) -> *mut UA_SessionState {
-        &mut self.0
+        &raw mut self.0
     }
 }


### PR DESCRIPTION
- Use `&raw` for pointers (`clippy --fix`).
- Remove obsolete and deprecated lint exception.