### PR TITLE
Decouple `AsyncClient`/`AsyncSubscription` from `tokio` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add method `AsyncMonitoredItem::delete()` to release server resources in a controlled manner
   asynchronously before dropping.
 - Add `MonitoredItemCreateRequestBuilder`.
+- `AsyncClient` and `AsyncSubscription` no longer depend on the `tokio` feature.
 
 ### Changed
 

--- a/src/async_subscription.rs
+++ b/src/async_subscription.rs
@@ -12,10 +12,7 @@ use open62541_sys::{
     UA_CreateSubscriptionResponse, UA_DeleteSubscriptionsResponse, UA_UInt32,
 };
 
-use crate::{
-    ua, AsyncClient, AsyncMonitoredItem, CallbackOnce, DataType as _, Error,
-    MonitoredItemCreateRequestBuilder, Result,
-};
+use crate::{ua, AsyncClient, CallbackOnce, DataType as _, Error, Result};
 
 #[derive(Debug, Default)]
 pub struct SubscriptionBuilder {
@@ -172,16 +169,20 @@ pub struct AsyncSubscription {
 }
 
 impl AsyncSubscription {
-    /// Creates [monitored item](AsyncMonitoredItem).
+    /// Creates [monitored item](crate::AsyncMonitoredItem).
     ///
     /// This creates a new monitored item for the given node.
     ///
     /// # Errors
     ///
     /// This fails when the node does not exist.
-    pub async fn create_monitored_item(&self, node_id: &ua::NodeId) -> Result<AsyncMonitoredItem> {
-        let request_builder = MonitoredItemCreateRequestBuilder::new([node_id.clone()]);
-        let results = AsyncMonitoredItem::create(self, request_builder).await?;
+    #[cfg(feature = "tokio")]
+    pub async fn create_monitored_item(
+        &self,
+        node_id: &ua::NodeId,
+    ) -> Result<crate::AsyncMonitoredItem> {
+        let request_builder = crate::MonitoredItemCreateRequestBuilder::new([node_id.clone()]);
+        let results = crate::AsyncMonitoredItem::create(self, request_builder).await?;
 
         // We expect exactly one result for the single monitored item we requested above.
         let Ok::<[_; 1], _>([result]) = results.try_into() else {
@@ -195,6 +196,7 @@ impl AsyncSubscription {
     }
 
     #[must_use]
+    #[cfg_attr(not(feature = "tokio"), expect(dead_code, reason = "unused"))]
     pub(crate) const fn client(&self) -> &Weak<ua::Client> {
         &self.client
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -376,7 +376,6 @@ impl Client {
     /// The [`AsyncClient`] can be used to access methods in an asynchronous way.
     ///
     /// [`AsyncClient`]: crate::AsyncClient
-    #[cfg(feature = "tokio")]
     #[must_use]
     pub fn into_async(self) -> crate::AsyncClient {
         crate::AsyncClient::from_sync(self.0)

--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -137,7 +137,6 @@ impl DataValue<ua::Variant> {
     /// This adjusts the target type of `self`, casting the inner value to the specified data type
     /// when read with [`Self::value()`]. This should be used in situations when the expected type
     /// can be deduced from circumstances and typed data values can be returned for convenience.
-    #[cfg_attr(not(feature = "tokio"), expect(dead_code, reason = "unused"))]
     pub(crate) fn cast<T: DataTypeExt>(self) -> DataValue<T> {
         let Self { data_value, _kind } = self;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,11 +208,9 @@
 //! # }
 //! ```
 
-#[cfg(feature = "tokio")]
 mod async_client;
 #[cfg(feature = "tokio")]
 mod async_monitored_item;
-#[cfg(feature = "tokio")]
 mod async_subscription;
 mod attributes;
 mod browse_result;
@@ -234,14 +232,12 @@ mod userdata;
 mod value;
 
 #[cfg(feature = "tokio")]
-use self::monitored_item::{create_monitored_items, delete_monitored_items, MonitoredItemHandle};
+pub use self::async_monitored_item::AsyncMonitoredItem;
 #[cfg(feature = "tokio")]
+use self::monitored_item::{create_monitored_items, delete_monitored_items, MonitoredItemHandle};
 pub use self::{
     async_client::AsyncClient,
-    async_monitored_item::AsyncMonitoredItem,
     async_subscription::{AsyncSubscription, SubscriptionBuilder},
-};
-pub use self::{
     browse_result::BrowseResult,
     client::{Client, ClientBuilder},
     data_type::DataType,

--- a/src/ua/data_types/browse_description.rs
+++ b/src/ua/data_types/browse_description.rs
@@ -41,7 +41,6 @@ impl BrowseDescription {
         self
     }
 
-    #[cfg_attr(not(feature = "tokio"), expect(dead_code, reason = "unused"))]
     #[must_use]
     pub(crate) fn node_id(&self) -> &ua::NodeId {
         ua::NodeId::raw_ref(&self.0.nodeId)


### PR DESCRIPTION
`AsyncClient::disconnect()` doesn't need to be `async`. It is inherently a synchronous method.

The caller is responsible for spawning an async task around blocking, synchronous invocations.