### PR TITLE
Safely transmute typed/untyped data values

### DIFF
--- a/src/data_value.rs
+++ b/src/data_value.rs
@@ -9,6 +9,9 @@ use crate::{ua, DataType, DataTypeExt};
 // Instead we implement all applicable traits manually by delegating
 // to the implementations for `ua::DataValue` (see below).
 #[derive(Debug)]
+// ABI must match that of the the untyped variant ua::DataValue.
+// Required to safely transmute both types.
+#[repr(transparent)]
 pub struct DataValue<T> {
     data_value: ua::DataValue,
     _kind: PhantomData<T>,


### PR DESCRIPTION
Add missing attribute.

Not needed yet, but probably what you would expect when working with typed `DataValue`s.