### PR TITLE
Construct ua::ExpandedNodeId from parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Return `Result` from `DataTypeExt::from_inner()`.
 - Breaking: Replace `ua::String::is_invalid()` with `ua::String::is_null()`.
 - Breaking: Replace `ua::ByteString::is_invalid()` with `ua::ByteString::is_null()`.
-- Breaking: Remove `into_expanded_node_id()` from `ua::NodeId`.
+- Breaking: Remove `into_expanded_node_id()` from `ua::NodeId`. Use `Into::into()` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add constructor `ua::Guid::new()`.
 - Add accessors for remaining `UA_NodeIdType` variants to `ua::NodeId`.
 - Add methods `null()` and `is_null()` to `ua::String` and `ua::ByteString`.
+- Add method `new()` to `ua::ExpandedNodeId`.
+- Add `From`/`Into` conversion from `ua::NodeId` to `ua::ExpandedNodeId`.
 
 ### Changed
 
@@ -26,6 +28,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Breaking: Return `Result` from `DataTypeExt::from_inner()`.
 - Breaking: Replace `ua::String::is_invalid()` with `ua::String::is_null()`.
 - Breaking: Replace `ua::ByteString::is_invalid()` with `ua::ByteString::is_null()`.
+- Breaking: Remove `into_expanded_node_id()` from `ua::NodeId`.
 
 ### Fixed
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -980,7 +980,7 @@ impl Server {
     /// server.add_reference(
     ///     &parent_two_node_id,
     ///     &ua::NodeId::ns0(UA_NS0ID_ORGANIZES),
-    ///     &variable_node_id.clone().into_expanded_node_id(),
+    ///     &variable_node_id.clone().into(),
     ///     true,
     /// )?;
     ///
@@ -988,7 +988,7 @@ impl Server {
     /// let error = server.add_reference(
     ///     &parent_one_node_id,
     ///     &ua::NodeId::ns0(UA_NS0ID_ORGANIZES),
-    ///     &variable_node_id.clone().into_expanded_node_id(),
+    ///     &variable_node_id.clone().into(),
     ///     true,
     /// ).unwrap_err();
     /// assert_eq!(error.status_code(), ua::StatusCode::BADDUPLICATEREFERENCENOTALLOWED);
@@ -1297,7 +1297,7 @@ impl Server {
     /// assert_eq!(
     ///     target.target_id(),
     ///     &ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME)
-    ///         .into_expanded_node_id()
+    ///         .into()
     /// );
     ///
     /// // All relative path elements were processed.
@@ -1372,7 +1372,7 @@ impl Server {
     /// assert_eq!(
     ///     target.target_id(),
     ///     &ua::NodeId::ns0(UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME)
-    ///         .into_expanded_node_id()
+    ///         .into()
     /// );
     ///
     /// // All relative path elements were processed.

--- a/src/ua/data_types/expanded_node_id.rs
+++ b/src/ua/data_types/expanded_node_id.rs
@@ -12,7 +12,26 @@ crate::data_type!(ExpandedNodeId);
 impl ExpandedNodeId {
     /// Creates expanded node ID.
     ///
-    /// Constructs a new instance from parts.
+    /// Constructs a new instance from parts by taking ownership.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use open62541::ua;
+    ///
+    /// let node_id = ua::NodeId::numeric(1, 234);
+    /// let namespace_uri = ua::String::new("http://www.example.com").unwrap();
+    /// let server_index = 99;
+    ///
+    /// let expanded_node_id = ua::ExpandedNodeId::new(
+    ///     node_id.clone(),
+    ///     namespace_uri.clone(),
+    ///     server_index);
+    ///
+    /// assert_eq!(expanded_node_id.node_id(), &node_id);
+    /// assert_eq!(expanded_node_id.namespace_uri(), &namespace_uri);
+    /// assert_eq!(expanded_node_id.server_index(), server_index);
+    /// ```
     #[must_use]
     pub fn new(node_id: ua::NodeId, namespace_uri: ua::String, server_index: u32) -> Self {
         let mut new = Self::from(node_id);

--- a/src/ua/data_types/expanded_node_id.rs
+++ b/src/ua/data_types/expanded_node_id.rs
@@ -101,7 +101,7 @@ impl str::FromStr for ExpandedNodeId {
 
         let status_code = ua::StatusCode::new({
             let str = ua::String::new(s)?;
-            // SAFETY: `UA_NodeId_parse()` expects the string passed by value but does not take
+            // SAFETY: `UA_ExpandedNodeId_parse()` expects the string passed by value but does not take
             // ownership.
             let str = unsafe { ua::String::to_raw_copy(&str) };
             unsafe { UA_ExpandedNodeId_parse(node_id.as_mut_ptr(), str) }

--- a/src/ua/data_types/expanded_node_id.rs
+++ b/src/ua/data_types/expanded_node_id.rs
@@ -10,6 +10,19 @@ use crate::{DataType as _, Error, ua};
 crate::data_type!(ExpandedNodeId);
 
 impl ExpandedNodeId {
+    /// Creates expanded node ID.
+    ///
+    /// Constructs a new instance from parts.
+    #[must_use]
+    pub fn new(node_id: ua::NodeId, namespace_uri: ua::String, server_index: u32) -> Self {
+        let mut new = Self::from(node_id);
+        debug_assert!(new.namespace_uri().is_null());
+        // This passes ownership into the created expanded node ID.
+        new.0.namespaceUri = namespace_uri.into_raw();
+        new.0.serverIndex = server_index;
+        new
+    }
+
     /// Creates numeric expanded node ID.
     #[must_use]
     pub fn numeric(ns_index: u16, numeric: u32) -> Self {
@@ -21,13 +34,6 @@ impl ExpandedNodeId {
         );
 
         Self(inner)
-    }
-
-    /// Creates expanded node ID from node ID.
-    #[must_use]
-    pub(crate) fn from_node_id(node_id: ua::NodeId) -> Self {
-        // This passes ownership into the created expanded node ID.
-        Self(unsafe { UA_EXPANDEDNODEID_NODEID(node_id.into_raw()) })
     }
 
     #[must_use]
@@ -43,6 +49,13 @@ impl ExpandedNodeId {
     #[must_use]
     pub const fn server_index(&self) -> u32 {
         self.0.serverIndex
+    }
+}
+
+impl From<ua::NodeId> for ExpandedNodeId {
+    fn from(node_id: ua::NodeId) -> Self {
+        // This passes ownership into the created expanded node ID.
+        Self(unsafe { UA_EXPANDEDNODEID_NODEID(node_id.into_raw()) })
     }
 }
 

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -206,12 +206,6 @@ impl NodeId {
             (self.0.namespaceIndex, ua::ByteString::raw_ref(identifier))
         })
     }
-
-    /// Turns node ID into expanded node ID.
-    #[must_use]
-    pub fn into_expanded_node_id(self) -> ua::ExpandedNodeId {
-        ua::ExpandedNodeId::from_node_id(self)
-    }
 }
 
 impl hash::Hash for NodeId {


### PR DESCRIPTION
Adds a more idiomatic way to construct `ua::ExpandedNodeId` from its component parts and standardizes conversion from `ua::NodeId` via Rust’s `From`/`Into` traits, while removing the older `NodeId::into_expanded_node_id()` helper.