### PR TITLE
Temporarily disable some ua::Server methods on aarch64-apple-darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- Temporarily disable the following methods in `ua::Server`on `aarch64-apple-darwin` due to
+- Temporarily disable the following methods in `ua::Server` on `aarch64-apple-darwin` due to
   [unresolved crashes](https://github.com/HMIProject/open62541/issues/325):
   - `ua::Server::add_reference()`
   - `ua::Server::read_object_property()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- Temporarily disable the following methods in `ua::Server` on `aarch64-apple-darwin` due to
-  [unresolved crashes](https://github.com/HMIProject/open62541/issues/325):
+- Breaking: Temporarily disable the following methods in `ua::Server` on `aarch64-apple-darwin` due
+  to [unresolved crashes](https://github.com/HMIProject/open62541/issues/325):
   - `ua::Server::add_reference()`
   - `ua::Server::read_object_property()`
   - `ua::Server::write_object_property()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add accessors for remaining `UA_NodeIdType` variants to `ua::NodeId`.
 - Add methods `null()` and `is_null()` to `ua::String` and `ua::ByteString`.
 
+### Removed
+
+- Temporarily disable the following methods in `ua::Server`on `aarch64-apple-darwin` due to
+  [unresolved crashes](https://github.com/HMIProject/open62541/issues/325):
+  - `ua::Server::add_reference()`
+  - `ua::Server::read_object_property()`
+  - `ua::Server::write_object_property()`
+
 ### Fixed
 
 - Fix linker errors for build target `x86_64-linux-unknown-gnu` by updating `open62541-sys` to

--- a/src/server.rs
+++ b/src/server.rs
@@ -981,7 +981,13 @@ impl Server {
         Error::verify_good(&status_code)
     }
 
+    // FIXME: Remove target restrictions.
+    // <https://github.com/HMIProject/open62541/issues/325>
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     /// Adds a reference from one node to another.
+    ///
+    /// Disabled on target `aarch64-apple-darwin` due to unresolved crashes. See also:
+    /// <https://github.com/HMIProject/open62541/issues/325>
     ///
     /// # Errors
     ///
@@ -1561,7 +1567,13 @@ impl Server {
         Error::verify_good(&status_code)
     }
 
+    // FIXME: Remove target restrictions.
+    // <https://github.com/HMIProject/open62541/issues/325>
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     /// Reads object property.
+    ///
+    /// Disabled on target `aarch64-apple-darwin` due to unresolved crashes. See also:
+    /// <https://github.com/HMIProject/open62541/issues/325>
     ///
     /// # Errors
     ///
@@ -1633,11 +1645,17 @@ impl Server {
         Ok(value)
     }
 
+    // FIXME: Remove target restrictions.
+    // <https://github.com/HMIProject/open62541/issues/325>
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     /// Writes object property.
     ///
     /// The property is represented as a `VariableNode` with a `HasProperty` reference from the
     /// `ObjectNode`. The `VariableNode` is identified by its `BrowseName`. Writing the property
     /// sets the value attribute of the `VariableNode`.
+    ///
+    /// Disabled on target `aarch64-apple-darwin` due to unresolved crashes. See also:
+    /// <https://github.com/HMIProject/open62541/issues/325>
     ///
     /// # Errors
     ///


### PR DESCRIPTION
- ua::Server::add_reference()
- ua::Server::read_object_property()
- ua::Server::write_object_property()

See also: <https://github.com/HMIProject/open62541/issues/325>