### PR TITLE
AsyncClient: Terminate background task only after cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix linker errors for build target `x86_64-linux-unknown-gnu` by updating `open62541-sys` to
   version 0.5.4 ([#288](https://github.com/HMIProject/open62541/issues/288)).
+- Improve handling of and recovery from connection loss in `AsyncClient`.
 
 ## [0.10.1] - 2025-10-29
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -719,7 +719,7 @@ enum BackgroundTaskState {
 }
 
 impl BackgroundTaskState {
-    // Map all possible states to u8 that could be store in an AtomicUi.
+    // Map all possible states to u8 that could be stored in an AtomicU8.
     const fn to_u8(self) -> u8 {
         match self {
             Self::Running => 0,

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -750,9 +750,13 @@ enum BackgroundTaskCancelledState {
 /// Background task for [`ua::Client`].
 ///
 /// This runs [`UA_Client_run_iterate()`] in a loop, blocking for up to `RUN_ITERATE_TIMEOUT` during
-/// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
-/// and for final connection failures), the cancellation token `cancel` can be used to stop the task
-/// from the outside before the next loop iteration.
+/// each iteration. Termination is controlled through the shared atomic `state`, which is checked
+/// between loop iterations. Setting the state to
+/// [`BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap)`] stops the task
+/// before the next iteration, while
+/// [`BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAfterNotConnected)`]
+/// requests graceful shutdown by continuing to service pending work until the client is no longer
+/// connected.
 fn background_task(client: &ua::Client, state: &AtomicU8) {
     log::info!("Starting background task");
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -123,7 +123,9 @@ impl AsyncClient {
                 log::warn!("Error while disconnecting client: {error}");
             }
         } else {
-            log::info!("Cannot disconnect client without background thread");
+            log::info!(
+                "Cannot disconnect client because background thread is not running or has already finished"
+            );
         }
 
         // Asynchronously wait for the background task running in the background thread to complete.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::c_void,
-    slice,
+    panic, slice,
     sync::{
         Arc, Weak,
         atomic::{AtomicU8, Ordering},
@@ -105,21 +105,26 @@ impl AsyncClient {
     pub async fn disconnect(mut self) {
         log::info!("Disconnecting from endpoint");
 
-        let status_code = ua::StatusCode::new(unsafe {
-            UA_Client_disconnectAsync(
-                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
-                self.client.as_ptr().cast_mut(),
-            )
-        });
-        if let Err(error) = Error::verify_good(&status_code) {
-            log::warn!("Error while disconnecting client: {error}");
-        }
-
         // PANIC: We only take the background thread here and in `drop()` (but that cannot have been
         // called yet). Since the method consumes `self`, the value must still be present. Note that
         // we the take value just before `await`, to uphold invariant in `Drop` implementation which
         // allows us to take an early return path there.
         let background_thread = self.background_thread.take().expect("no background thread");
+
+        // Disconnecting requires driving the internal event loop.
+        if background_thread.is_running_and_not_finished_yet() {
+            let status_code = ua::StatusCode::new(unsafe {
+                UA_Client_disconnectAsync(
+                    // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                    self.client.as_ptr().cast_mut(),
+                )
+            });
+            if let Err(error) = Error::verify_good(&status_code) {
+                log::warn!("Error while disconnecting client: {error}");
+            }
+        } else {
+            log::info!("Cannot disconnect client without background thread");
+        }
 
         // Asynchronously wait for the background task running in the background thread to complete.
         //
@@ -127,7 +132,7 @@ impl AsyncClient {
         // handling to keep on running until the connection has been taken down which then makes the
         // task finish by itself.
         background_thread.cancel(BackgroundTheadCancelledState::TerminateAfterNotConnected);
-        background_thread.wait_until_done().await;
+        background_thread.wait_until_finished().await;
     }
 
     /// Reads node value.
@@ -601,14 +606,14 @@ enum BackgroundTheadCancelledState {
 #[derive(Debug)]
 struct BackgroundThread {
     state: Arc<AtomicU8>,
-    done_rx: oneshot::Receiver<()>,
+    finished_rx: oneshot::Receiver<()>,
     handle: JoinHandle<()>,
 }
 
 impl BackgroundThread {
     fn spawn(client: Arc<ua::Client>) -> Self {
         let state = Arc::new(AtomicU8::new(BackgroundTheadState::Running.to_u8()));
-        let (done_tx, done_rx) = oneshot::channel();
+        let (finished_tx, finished_rx) = oneshot::channel();
 
         // Run the event loop concurrently. We do so on a thread where we may block: we need to call
         // `UA_Client_run_iterate()` and this method blocks for up to `RUN_ITERATE_TIMEOUT`.
@@ -619,17 +624,36 @@ impl BackgroundThread {
         let handle = {
             let state = Arc::clone(&state);
             thread::spawn(move || {
-                background_task(&client, &state);
-                log::info!("Background task finished");
-                let _unused = done_tx.send(());
+                let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    background_thread(&client, &state)
+                }));
+                match result {
+                    Ok(()) => {
+                        log::info!("Background task terminated");
+                        let _unused = finished_tx.send(());
+                    }
+                    Err(panicked) => {
+                        log::info!("Background task panicked");
+                        let _unused = finished_tx.send(());
+                        // Forward the panic.
+                        panic::resume_unwind(panicked);
+                        // Unreachable
+                    }
+                }
             })
         };
 
         Self {
             state,
-            done_rx,
+            finished_rx,
             handle,
         }
+    }
+
+    #[must_use]
+    fn is_running_and_not_finished_yet(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == BackgroundTheadState::Running.to_u8()
+            && !self.handle.is_finished()
     }
 
     fn cancel(&self, cancelled: BackgroundTheadCancelledState) {
@@ -687,12 +711,26 @@ impl BackgroundThread {
         let _unused = handle.join();
     }
 
-    async fn wait_until_done(self) {
-        let Self { done_rx, .. } = self;
+    async fn wait_until_finished(self) {
+        let Self {
+            state,
+            finished_rx,
+            handle,
+        } = self;
+        debug_assert_ne!(
+            state.load(Ordering::Relaxed),
+            BackgroundTheadState::Running.to_u8()
+        );
+
+        if handle.is_finished() {
+            return;
+        }
 
         // We ignore the result: the sender is only dropped when the background thread has finished,
         // which is exactly what we are waiting for anyway.
-        let _unused = done_rx.await;
+        let _unused = finished_rx.await;
+
+        debug_assert!(handle.is_finished());
     }
 }
 
@@ -702,7 +740,7 @@ impl BackgroundThread {
 /// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
 /// and for final connection failures), the cancellation token `cancel` can be used to stop the task
 /// from the outside before the next loop iteration.
-fn background_task(client: &ua::Client, state: &AtomicU8) {
+fn background_thread(client: &ua::Client, state: &AtomicU8) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -536,9 +536,7 @@ impl AsyncClient {
             .as_ref()
             .is_none_or(|background_thread| !background_thread.is_running_and_not_finished_yet())
         {
-            return Err(Error::new(ua::StatusCode::new(
-                UA_STATUSCODE_BADDISCONNECT,
-            )));
+            return Err(Error::new(ua::StatusCode::new(UA_STATUSCODE_BADDISCONNECT)));
         }
         log::debug!("Running {}", R::type_name());
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -522,6 +522,19 @@ impl AsyncClient {
             let _unused = tx.send(result.map_err(Error::new));
         };
 
+        // Reject requests if the background thread is not running immediately before submission.
+        //
+        // Without the background thread requests will not be serviced and the
+        // async invocation would be pending forever. Due to race conditions this
+        // could happen at any time and callers are encouraged to enclose asynchronous
+        // calls with timeouts.
+        if self
+            .background_thread
+            .as_ref()
+            .is_none_or(|background_thread| !background_thread.is_running_and_not_finished_yet())
+        {
+            return Err(Error::Internal("no background thread"));
+        }
         log::debug!("Running {}", R::type_name());
 
         let mut request_id: UA_UInt32 = 0;
@@ -606,8 +619,8 @@ enum BackgroundTheadCancelledState {
 #[derive(Debug)]
 struct BackgroundThread {
     state: Arc<AtomicU8>,
-    finished_rx: oneshot::Receiver<()>,
     handle: JoinHandle<()>,
+    finished_rx: oneshot::Receiver<()>,
 }
 
 impl BackgroundThread {
@@ -625,15 +638,13 @@ impl BackgroundThread {
             let state = Arc::clone(&state);
             thread::spawn(move || {
                 let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    background_thread(&client, &state)
+                    let () = background_thread(&client, &state);
                 }));
                 match result {
                     Ok(()) => {
-                        log::info!("Background task terminated");
                         let _unused = finished_tx.send(());
                     }
                     Err(panicked) => {
-                        log::info!("Background task panicked");
                         let _unused = finished_tx.send(());
                         // Forward the panic.
                         panic::resume_unwind(panicked);
@@ -645,8 +656,8 @@ impl BackgroundThread {
 
         Self {
             state,
-            finished_rx,
             handle,
+            finished_rx,
         }
     }
 
@@ -714,8 +725,8 @@ impl BackgroundThread {
     async fn wait_until_finished(self) {
         let Self {
             state,
-            finished_rx,
             handle,
+            finished_rx,
         } = self;
         debug_assert_ne!(
             state.load(Ordering::Relaxed),

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -744,9 +744,9 @@ enum BackgroundTaskCancellationMode {
 /// This runs [`UA_Client_run_iterate()`] in a loop, blocking for up to `RUN_ITERATE_TIMEOUT` during
 /// each iteration. Termination is controlled through the shared atomic `state`, which is checked
 /// between loop iterations. Setting the state to
-/// [`BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap)`] stops the task
-/// before the next iteration, while
-/// [`BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAfterNotConnected)`]
+/// [`BackgroundTaskState::Cancelled { mode: BackgroundTaskCancellationMode::TerminateAsap }`]
+/// stops the task before the next iteration, while
+/// [`BackgroundTaskState::Cancelled { mode: BackgroundTaskCancellationMode::TerminateAfterNotConnected }`]
 /// requests graceful shutdown by continuing to service pending work until the client is no longer
 /// connected.
 fn background_task(client: &ua::Client, state: &AtomicU8) {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -135,9 +135,7 @@ impl AsyncClient {
         // connection has been taken down, at which point the background task can finish and we wait
         // for that completion here.
         background_thread.cancel(BackgroundTaskCancellationMode::TerminateAfterNotConnected);
-        background_thread
-            .wait_until_finished_after_cancelled()
-            .await;
+        background_thread.join_after_cancelled().await;
     }
 
     /// Reads node value.
@@ -592,7 +590,7 @@ impl Drop for AsyncClient {
 
         log::info!("Cancelling and joining background task when dropping client");
         background_thread.cancel(BackgroundTaskCancellationMode::TerminateAsap);
-        background_thread.join_after_cancelled();
+        background_thread.join_after_cancelled_blocking();
 
         log::info!("Background task finished when dropping client");
     }
@@ -602,13 +600,13 @@ impl Drop for AsyncClient {
 struct BackgroundThread {
     state: Arc<AtomicU8>,
     handle: JoinHandle<()>,
-    finished_rx: oneshot::Receiver<()>,
+    terminated_rx: oneshot::Receiver<()>,
 }
 
 impl BackgroundThread {
     fn spawn(client: Arc<ua::Client>) -> Self {
         let state = Arc::new(AtomicU8::new(BackgroundTaskState::Running.to_u8()));
-        let (finished_tx, finished_rx) = oneshot::channel();
+        let (terminated_tx, terminated_rx) = oneshot::channel();
 
         // Run the event loop concurrently. We do so on a thread where we may block: we need to call
         // `UA_Client_run_iterate()` and this method blocks for up to `RUN_ITERATE_TIMEOUT`.
@@ -620,17 +618,17 @@ impl BackgroundThread {
             let state = Arc::clone(&state);
             thread::spawn(move || {
                 let () = background_task(&client, &state);
-                log::info!("Background task finished");
+                log::info!("Background task terminated");
                 // The send() is redundant here, because dropping the sender will also wake up and unblock the receiver.
-                // finished_tx will be dropped implicitly even if background_task() panics.
-                let _unused = finished_tx.send(());
+                // terminated_tx will be dropped implicitly even if background_task() panics.
+                let _unused = terminated_tx.send(());
             })
         };
 
         Self {
             state,
             handle,
-            finished_rx,
+            terminated_rx,
         }
     }
 
@@ -647,8 +645,12 @@ impl BackgroundThread {
         );
     }
 
-    fn join_after_cancelled(self) {
-        let Self { state, handle, .. } = self;
+    fn join_after_cancelled_blocking(self) {
+        let Self {
+            state,
+            handle,
+            terminated_rx,
+        } = self;
         debug_assert_ne!(
             state.load(Ordering::Relaxed),
             BackgroundTaskState::Running.to_u8()
@@ -665,6 +667,7 @@ impl BackgroundThread {
         // threads may cause deadlocks and must be avoided.
         #[cfg(feature = "tokio")]
         if let Ok(rt) = &tokio::runtime::Handle::try_current() {
+            let mut terminated_rx = terminated_rx;
             if matches!(
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
@@ -673,6 +676,7 @@ impl BackgroundThread {
                 tokio::task::block_in_place(move || {
                     let _unused = handle.join();
                 });
+                debug_assert!(terminated_rx.try_recv().is_err());
             } else {
                 // Offload the synchronous invocation from the executor thread onto a worker thread.
                 let join_handle = rt.spawn_blocking(move || {
@@ -682,20 +686,23 @@ impl BackgroundThread {
                 tokio::task::block_in_place(move || {
                     rt.block_on(async move {
                         let _unused = join_handle.await;
+                        debug_assert!(terminated_rx.try_recv().is_err());
                     });
                 });
             }
             return;
         }
+        #[cfg(not(feature = "tokio"))]
+        drop(terminated_rx);
 
         let _unused = handle.join();
     }
 
-    async fn wait_until_finished_after_cancelled(self) {
+    async fn join_after_cancelled(self) {
         let Self {
             state,
             handle,
-            finished_rx,
+            terminated_rx,
         } = self;
         debug_assert_ne!(
             state.load(Ordering::Relaxed),
@@ -703,14 +710,21 @@ impl BackgroundThread {
         );
 
         if handle.is_finished() {
+            // Nothing to do.
             return;
         }
 
+        // Asynchronously wait for the background task to terminate.
+        //
         // We ignore the result: the sender is only dropped when the background thread has finished,
-        // which is exactly what we are waiting for anyway.
-        let _unused = finished_rx.await;
+        // which is exactly what we are waiting for anyway in the next step.
+        let _unused = terminated_rx.await;
 
-        debug_assert!(handle.is_finished());
+        // After the background task has terminated the background thread should finish instantly.
+        #[cfg(feature = "tokio")]
+        tokio::task::block_in_place(move || {
+            let _unused = handle.join();
+        });
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -3,7 +3,7 @@ use std::{
     slice,
     sync::{
         Arc, Weak,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicU8, Ordering},
     },
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -12,7 +12,8 @@ use std::{
 use futures_channel::oneshot;
 use open62541_sys::{
     __UA_Client_AsyncService, UA_Client, UA_Client_disconnectAsync, UA_Client_run_iterate,
-    UA_STATUSCODE_BADCONNECTIONCLOSED, UA_STATUSCODE_BADDISCONNECT, UA_UInt32,
+    UA_STATUSCODE_BADCONNECTIONCLOSED, UA_STATUSCODE_BADCONNECTIONREJECTED,
+    UA_STATUSCODE_BADDISCONNECT, UA_UInt32,
 };
 
 use crate::{
@@ -122,9 +123,10 @@ impl AsyncClient {
 
         // Asynchronously wait for the background task running in the background thread to complete.
         //
-        // Note: We do _not_ cancel the background task before blocking: we require the asynchronous
+        // Note: We do _not_ abort the background task before blocking: we require the asynchronous
         // handling to keep on running until the connection has been taken down which then makes the
         // task finish by itself.
+        background_thread.cancel(BackgroundTheadCancelledState::TerminateAfterNotConnected);
         background_thread.wait_until_done().await;
     }
 
@@ -564,22 +566,48 @@ impl Drop for AsyncClient {
         };
 
         log::info!("Cancelling and joining background task when dropping client");
-        background_thread.cancel_and_join();
+        background_thread.cancel_and_join(BackgroundTheadCancelledState::Aborted);
 
         log::info!("Background task finished when dropping client");
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum BackgroundTheadState {
+    Running,
+    Cancelled(BackgroundTheadCancelledState),
+}
+
+impl BackgroundTheadState {
+    // Conversion to u8 is needed to store the state in an AtomicU8.
+    const fn to_u8(self) -> u8 {
+        match self {
+            Self::Running => 0,
+            Self::Cancelled(cancelled) => match cancelled {
+                BackgroundTheadCancelledState::TerminateAfterNotConnected => 1,
+                BackgroundTheadCancelledState::Aborted => 2,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackgroundTheadCancelledState {
+    /// terminate gracefully.
+    TerminateAfterNotConnected,
+    Aborted,
+}
+
 #[derive(Debug)]
 struct BackgroundThread {
-    cancelled: Arc<AtomicBool>,
+    state: Arc<AtomicU8>,
     done_rx: oneshot::Receiver<()>,
     handle: JoinHandle<()>,
 }
 
 impl BackgroundThread {
     fn spawn(client: Arc<ua::Client>) -> Self {
-        let cancelled = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(AtomicU8::new(BackgroundTheadState::Running.to_u8()));
         let (done_tx, done_rx) = oneshot::channel();
 
         // Run the event loop concurrently. We do so on a thread where we may block: we need to call
@@ -589,30 +617,38 @@ impl BackgroundThread {
         // the task blockingly in `drop()` and this requires proper concurrency (otherwise, we would
         // risk deadlocking on single-threaded tokio runners).
         let handle = {
-            let cancelled = Arc::clone(&cancelled);
+            let state = Arc::clone(&state);
             thread::spawn(move || {
-                background_task(&client, &cancelled);
+                background_task(&client, &state);
                 log::info!("Background task finished");
                 let _unused = done_tx.send(());
             })
         };
 
         Self {
-            cancelled,
+            state,
             done_rx,
             handle,
         }
     }
 
-    fn cancel_and_join(self) {
-        let Self {
-            cancelled, handle, ..
-        } = self;
+    fn cancel(&self, cancelled: BackgroundTheadCancelledState) {
+        self.state.store(
+            BackgroundTheadState::Cancelled(cancelled).to_u8(),
+            Ordering::Relaxed,
+        );
+    }
+
+    fn cancel_and_join(self, cancelled: BackgroundTheadCancelledState) {
+        let Self { state, handle, .. } = self;
 
         // Notify background task to cancel itself, even when [`UA_Client_run_iterate()`] would want
         // to keep on running. This is okay: we are not issuing asynchronous requests anymore anyway
         // (the only other call will be `UA_Client_delete()` when inner client drops).
-        cancelled.store(true, Ordering::Relaxed);
+        state.store(
+            BackgroundTheadState::Cancelled(cancelled).to_u8(),
+            Ordering::Relaxed,
+        );
 
         // We need to wait for the task to finish and must do so blockingly. `UA_Client_delete()` is
         // not safe run concurrently while `UA_Client_run_iterate()` is still running. We ignore the
@@ -666,7 +702,7 @@ impl BackgroundThread {
 /// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
 /// and for final connection failures), the cancellation token `cancel` can be used to stop the task
 /// from the outside before the next loop iteration.
-fn background_task(client: &ua::Client, cancelled: &AtomicBool) {
+fn background_task(client: &ua::Client, state: &AtomicU8) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.
@@ -674,7 +710,9 @@ fn background_task(client: &ua::Client, cancelled: &AtomicBool) {
 
     // Run until cancelled. The only other way to exit is when `UA_Client_run_iterate()` fails which
     // happens when the connection is broken and the client instance cannot be used anymore.
-    while !cancelled.load(Ordering::Relaxed) {
+    while let state = state.load(Ordering::Relaxed)
+        && state != BackgroundTheadState::Cancelled(BackgroundTheadCancelledState::Aborted).to_u8()
+    {
         // Track time of iteration start to report iteration times below.
         let start_of_iteration = Instant::now();
 
@@ -692,20 +730,28 @@ fn background_task(client: &ua::Client, cancelled: &AtomicBool) {
                 )
             }
         });
-        if let Err(error) = Error::verify_good(&status_code) {
-            // Context-sensitive handling of bad status codes.
-            let status_code = status_code.into_raw();
-            if status_code == UA_STATUSCODE_BADDISCONNECT {
-                // Not an error.
-                log::info!("Terminating background task after disconnect");
-            } else if status_code == UA_STATUSCODE_BADCONNECTIONCLOSED {
-                // Not an error.
-                log::info!("Terminating background task after connection closed");
-            } else {
-                // Unexpected error.
-                log::error!("Terminating background task: run failed with {error}");
+        if let Err(err) = Error::verify_good(&status_code) {
+            match status_code.into_raw() {
+                UA_STATUSCODE_BADDISCONNECT
+                | UA_STATUSCODE_BADCONNECTIONCLOSED
+                | UA_STATUSCODE_BADCONNECTIONREJECTED => {
+                    // Not an error.
+                    if state
+                        == BackgroundTheadState::Cancelled(
+                            BackgroundTheadCancelledState::TerminateAfterNotConnected,
+                        )
+                        .to_u8()
+                    {
+                        log::info!("Terminating background task after not connected");
+                        return;
+                    }
+                }
+                _ => {
+                    // Unexpected error.
+                    log::error!("Terminating background task after unexpected error: {err:#}");
+                    return;
+                }
             }
-            return;
         }
 
         let time_taken = start_of_iteration.elapsed();

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -681,16 +681,18 @@ impl BackgroundThread {
         // After the background task has terminated the background thread should finish almost instantly.
         #[cfg(feature = "tokio")]
         {
-            // The enclosing `async fn` is supposed to run on a Tokio runtime thread.
-            // Spawning a worker thread for joining the background thread synchronously
-            // works independent of the runtime flavor (single/multi-threaded).
-            let _unused = tokio::task::spawn_blocking(join_background_thread_blocking).await;
+            // The enclosing `async fn` is probably running on a Tokio runtime thread,
+            // but we cannot be sure.
+            if let Ok(rt) = tokio::runtime::Handle::try_current() {
+                // Spawning a worker thread for joining the background thread synchronously
+                // works independent of the runtime flavor (single/multi-threaded).
+                let _unused = rt.spawn_blocking(join_background_thread_blocking).await;
+                return;
+            }
         }
-        #[cfg(not(feature = "tokio"))]
-        {
-            log::warn!("Blocking async runtime thread to join background thread");
-            join_background_thread_blocking();
-        }
+
+        log::warn!("Blocking async runtime thread to join background thread");
+        join_background_thread_blocking();
     }
 
     fn join_after_cancelled_on_drop_blocking(self) {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -522,19 +522,13 @@ impl AsyncClient {
             let _unused = tx.send(result.map_err(Error::new));
         };
 
-        // Reject requests if the background thread is not running immediately before submission.
-        //
-        // Without the background thread requests will not be serviced and the
-        // async invocation would be pending forever. Due to race conditions this
-        // could happen at any time and callers are encouraged to enclose asynchronous
-        // calls with timeouts.
-        if self
-            .background_thread
-            .as_ref()
-            .is_none_or(|background_thread| !background_thread.is_running_and_not_finished_yet())
-        {
-            return Err(Error::new(ua::StatusCode::new(UA_STATUSCODE_BADDISCONNECT)));
-        }
+        // The background thread only terminates and finishes after being cancelled. This could only
+        // happen in disconnect() by consuming self or in drop().
+        debug_assert!(
+            self.background_thread
+                .as_ref()
+                .is_some_and(BackgroundThread::is_running_and_not_finished_yet)
+        );
         log::debug!("Running {}", R::type_name());
 
         let mut request_id: UA_UInt32 = 0;

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -716,12 +716,14 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
         // Track time of iteration start to report iteration times below.
         let start_of_iteration = Instant::now();
 
-        let status_code = ua::StatusCode::new({
+        let connect_status = ua::StatusCode::new({
             log::trace!("Running iterate");
 
             // This returns after the timeout even when nothing was processed. The internal mutex is
             // _not_ held for the entire time though, so we can send out requests concurrently while
             // the client is running the iteration.
+            //
+            // The invocation returns with the current connect status.
             unsafe {
                 UA_Client_run_iterate(
                     // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
@@ -730,8 +732,8 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
                 )
             }
         });
-        if let Err(err) = Error::verify_good(&status_code) {
-            match status_code.into_raw() {
+        if let Err(err) = Error::verify_good(&connect_status) {
+            match connect_status.into_raw() {
                 UA_STATUSCODE_BADDISCONNECT
                 | UA_STATUSCODE_BADCONNECTIONCLOSED
                 | UA_STATUSCODE_BADCONNECTIONREJECTED => {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -40,7 +40,7 @@ const RUN_ITERATE_TIMEOUT: Duration = Duration::from_millis(200);
 /// while being dropped. In most cases, this is not the desired behavior.
 ///
 /// With feature `tokio` enabled, blocking invocations in [`AsyncClient::drop()`] might be offloaded
-/// from executor to worker threads as needed to prevent deadlocks. However, this can be implemented
+/// from runtime to worker threads as needed to prevent deadlocks. However, this can be implemented
 /// only when running in [multi-threaded runtimes]. When using current-thread runtime (or some other
 /// asynchronous runtime), make sure to not invoke [`AsyncClient::drop()`] in asynchronous contexts.
 ///
@@ -590,7 +590,7 @@ impl Drop for AsyncClient {
 
         log::info!("Cancelling and joining background task when dropping client");
         background_thread.cancel(BackgroundTaskCancellationMode::TerminateAsap);
-        background_thread.join_after_cancelled_blocking();
+        background_thread.join_after_cancelled_on_drop_blocking();
 
         log::info!("Background task finished when dropping client");
     }
@@ -645,57 +645,6 @@ impl BackgroundThread {
         );
     }
 
-    fn join_after_cancelled_blocking(self) {
-        let Self {
-            state,
-            handle,
-            terminated_rx: _,
-        } = self;
-        debug_assert_ne!(
-            state.load(Ordering::Relaxed),
-            BackgroundTaskState::Running.to_u8()
-        );
-
-        // We need to wait for the task to finish and must do so blockingly. `UA_Client_delete()` is
-        // not safe run concurrently while `UA_Client_run_iterate()` is still running. We ignore the
-        // result, because we do not care if the thread panicked (and there is nothing that we could
-        // do anyway in that case).
-        // TODO: Use `tracing` and span to group log messages.
-        log::info!("Waiting for background task to finish after cancelling");
-
-        let join_background_thread_blocking = move || {
-            let _unused = handle.join();
-        };
-
-        // `AsyncClient` is supposed to be used in asynchronous context. Note that blocking executor
-        // threads may cause deadlocks and must be avoided.
-        #[cfg(feature = "tokio")]
-        if let Ok(rt) = &tokio::runtime::Handle::try_current() {
-            // Asynchronous context.
-            if matches!(
-                rt.runtime_flavor(),
-                tokio::runtime::RuntimeFlavor::CurrentThread
-            ) {
-                // Using tokio::task::block_in_place() here would panic.
-                log::warn!("Blocking executor thread to join background thread");
-                // Continue below.
-            } else {
-                // Offload the synchronous, blocking invocation from the executor thread
-                // onto a worker thread.
-                let join_handle = rt.spawn_blocking(join_background_thread_blocking);
-                // Re-enter the asynchronous context for joining the worker thread.
-                tokio::task::block_in_place(move || {
-                    rt.block_on(async move {
-                        let _unused = join_handle.await;
-                    });
-                });
-                return;
-            }
-        }
-
-        join_background_thread_blocking();
-    }
-
     async fn join_after_cancelled(self) {
         let Self {
             state,
@@ -712,33 +661,85 @@ impl BackgroundThread {
             return;
         }
 
+        // TODO: Use `tracing` and span to group log messages.
+        log::info!("Waiting for background task to finish after cancelling");
+
+        // We need to wait for the task to finish and must do so blockingly.
+        // `UA_Client_delete()` is not safe to run concurrently while `UA_Client_run_iterate()`
+        // is still running. We ignore the result, because we do not care if the thread panicked
+        // (and there is nothing that we could do anyway in that case).
+        let join_background_thread_blocking = move || {
+            let _unused = handle.join();
+        };
+
         // Asynchronously wait for the background task to terminate.
         //
         // We ignore the result: the sender is only dropped when the background thread has finished,
         // which is exactly what we are waiting for anyway in the next step.
         let _unused = terminated_rx.await;
 
-        // After the background task has terminated the background thread should finish instantly.
+        // After the background task has terminated the background thread should finish almost instantly.
         #[cfg(feature = "tokio")]
         {
-            // This `async fn` is supposed to run on a Tokio executor thread.
-            // Otherwise obtaining a runtime handle would panic as expected.
-            let rt = tokio::runtime::Handle::current();
+            // The enclosing `async fn` is supposed to run on a Tokio runtime thread.
+            // Spawning a worker thread for joining the background thread synchronously
+            // works independent of the runtime flavor (single/multi-threaded).
+            let _unused = tokio::task::spawn_blocking(join_background_thread_blocking).await;
+        }
+        #[cfg(not(feature = "tokio"))]
+        {
+            log::warn!("Blocking async runtime thread to join background thread");
+            join_background_thread_blocking();
+        }
+    }
+
+    fn join_after_cancelled_on_drop_blocking(self) {
+        let Self {
+            state,
+            handle,
+            // The one-shot channel receiver is useless here.
+            terminated_rx: _,
+        } = self;
+        debug_assert_ne!(
+            state.load(Ordering::Relaxed),
+            BackgroundTaskState::Running.to_u8()
+        );
+
+        if handle.is_finished() {
+            // Nothing to do.
+            return;
+        }
+
+        // TODO: Use `tracing` and span to group log messages.
+        log::info!("Waiting for background task to finish after cancelling (blocking)");
+
+        // We need to wait for the task to finish and must do so blockingly.
+        // `UA_Client_delete()` is not safe to run concurrently while `UA_Client_run_iterate()`
+        // is still running. We ignore the result, because we do not care if the thread panicked
+        // (and there is nothing that we could do anyway in that case).
+        let join_background_thread_blocking = move || {
+            let _unused = handle.join();
+        };
+
+        // `AsyncClient` is supposed to be used in asynchronous context. Note that blocking runtime
+        // threads may cause deadlocks and must be avoided.
+        #[cfg(feature = "tokio")]
+        if let Ok(rt) = &tokio::runtime::Handle::try_current() {
+            // Asynchronous context.
             if matches!(
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
                 // Using tokio::task::block_in_place() here would panic.
-                let _unused = tokio::task::spawn_blocking(move || {
-                    let _unused = handle.join();
-                })
-                .await;
+                log::warn!("Blocking async runtime thread to join background thread");
+                // Continue below.
             } else {
-                tokio::task::block_in_place(move || {
-                    let _unused = handle.join();
-                });
+                tokio::task::block_in_place(join_background_thread_blocking);
+                return;
             }
         }
+
+        join_background_thread_blocking();
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -107,7 +107,7 @@ impl AsyncClient {
 
         // PANIC: We only take the background thread here and in `drop()` (but that cannot have been
         // called yet). Since the method consumes `self`, the value must still be present. Note that
-        // we the take value just before `await`, to uphold invariant in `Drop` implementation which
+        // we take the value just before `await`, to uphold invariant in `Drop` implementation which
         // allows us to take an early return path there.
         let background_thread = self.background_thread.take().expect("no background thread");
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -613,6 +613,7 @@ impl BackgroundThread {
             let state = Arc::clone(&state);
             thread::spawn(move || {
                 let () = background_task(&client, &state);
+                log::info!("Background task finished");
                 // The send() is redundant here, because dropping the sender will also wake up and unblock the receiver.
                 // finished_tx will be dropped implicitly even if background_task() panics.
                 let _unused = finished_tx.send(());

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -128,9 +128,10 @@ impl AsyncClient {
 
         // Asynchronously wait for the background task running in the background thread to complete.
         //
-        // Note: We do _not_ abort the background task before blocking: we require the asynchronous
-        // handling to keep on running until the connection has been taken down which then makes the
-        // task finish by itself.
+        // Note: We first request graceful cancellation before blocking. The
+        // `TerminateAfterNotConnected` mode keeps the asynchronous handling running until the
+        // connection has been taken down, at which point the background task can finish and we wait
+        // for that completion here.
         background_thread.cancel(BackgroundTaskCancelledState::TerminateAfterNotConnected);
         background_thread.wait_until_finished().await;
     }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -131,7 +131,7 @@ impl AsyncClient {
         // Note: We do _not_ abort the background task before blocking: we require the asynchronous
         // handling to keep on running until the connection has been taken down which then makes the
         // task finish by itself.
-        background_thread.cancel(BackgroundTheadCancelledState::TerminateAfterNotConnected);
+        background_thread.cancel(BackgroundTaskCancelledState::TerminateAfterNotConnected);
         background_thread.wait_until_finished().await;
     }
 
@@ -584,36 +584,10 @@ impl Drop for AsyncClient {
         };
 
         log::info!("Cancelling and joining background task when dropping client");
-        background_thread.cancel_and_join(BackgroundTheadCancelledState::Aborted);
+        background_thread.cancel_and_join(BackgroundTaskCancelledState::TerminateAsap);
 
         log::info!("Background task finished when dropping client");
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum BackgroundTheadState {
-    Running,
-    Cancelled(BackgroundTheadCancelledState),
-}
-
-impl BackgroundTheadState {
-    // Conversion to u8 is needed to store the state in an AtomicU8.
-    const fn to_u8(self) -> u8 {
-        match self {
-            Self::Running => 0,
-            Self::Cancelled(cancelled) => match cancelled {
-                BackgroundTheadCancelledState::TerminateAfterNotConnected => 1,
-                BackgroundTheadCancelledState::Aborted => 2,
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum BackgroundTheadCancelledState {
-    /// terminate gracefully.
-    TerminateAfterNotConnected,
-    Aborted,
 }
 
 #[derive(Debug)]
@@ -625,7 +599,7 @@ struct BackgroundThread {
 
 impl BackgroundThread {
     fn spawn(client: Arc<ua::Client>) -> Self {
-        let state = Arc::new(AtomicU8::new(BackgroundTheadState::Running.to_u8()));
+        let state = Arc::new(AtomicU8::new(BackgroundTaskState::Running.to_u8()));
         let (finished_tx, finished_rx) = oneshot::channel();
 
         // Run the event loop concurrently. We do so on a thread where we may block: we need to call
@@ -638,7 +612,7 @@ impl BackgroundThread {
             let state = Arc::clone(&state);
             thread::spawn(move || {
                 let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    let () = background_thread(&client, &state);
+                    let () = background_task(&client, &state);
                 }));
                 match result {
                     Ok(()) => {
@@ -663,25 +637,25 @@ impl BackgroundThread {
 
     #[must_use]
     fn is_running_and_not_finished_yet(&self) -> bool {
-        self.state.load(Ordering::Relaxed) == BackgroundTheadState::Running.to_u8()
+        self.state.load(Ordering::Relaxed) == BackgroundTaskState::Running.to_u8()
             && !self.handle.is_finished()
     }
 
-    fn cancel(&self, cancelled: BackgroundTheadCancelledState) {
+    fn cancel(&self, cancelled: BackgroundTaskCancelledState) {
         self.state.store(
-            BackgroundTheadState::Cancelled(cancelled).to_u8(),
+            BackgroundTaskState::Cancelled(cancelled).to_u8(),
             Ordering::Relaxed,
         );
     }
 
-    fn cancel_and_join(self, cancelled: BackgroundTheadCancelledState) {
+    fn cancel_and_join(self, cancelled: BackgroundTaskCancelledState) {
         let Self { state, handle, .. } = self;
 
         // Notify background task to cancel itself, even when [`UA_Client_run_iterate()`] would want
         // to keep on running. This is okay: we are not issuing asynchronous requests anymore anyway
         // (the only other call will be `UA_Client_delete()` when inner client drops).
         state.store(
-            BackgroundTheadState::Cancelled(cancelled).to_u8(),
+            BackgroundTaskState::Cancelled(cancelled).to_u8(),
             Ordering::Relaxed,
         );
 
@@ -730,7 +704,7 @@ impl BackgroundThread {
         } = self;
         debug_assert_ne!(
             state.load(Ordering::Relaxed),
-            BackgroundTheadState::Running.to_u8()
+            BackgroundTaskState::Running.to_u8()
         );
 
         if handle.is_finished() {
@@ -745,13 +719,40 @@ impl BackgroundThread {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum BackgroundTaskState {
+    Running,
+    Cancelled(BackgroundTaskCancelledState),
+}
+
+impl BackgroundTaskState {
+    // Conversion to u8 is needed to store the state in an AtomicU8.
+    const fn to_u8(self) -> u8 {
+        match self {
+            Self::Running => 0,
+            Self::Cancelled(cancelled) => match cancelled {
+                BackgroundTaskCancelledState::TerminateAfterNotConnected => 1,
+                BackgroundTaskCancelledState::TerminateAsap => 2,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackgroundTaskCancelledState {
+    /// Terminate gracefully by servicing all pending requests until no longer connected.
+    TerminateAfterNotConnected,
+    /// Terminate as soon as possible.
+    TerminateAsap,
+}
+
 /// Background task for [`ua::Client`].
 ///
 /// This runs [`UA_Client_run_iterate()`] in a loop, blocking for up to `RUN_ITERATE_TIMEOUT` during
 /// each iteration. In case the loop does not finish by itself (which happens in case of disconnects
 /// and for final connection failures), the cancellation token `cancel` can be used to stop the task
 /// from the outside before the next loop iteration.
-fn background_thread(client: &ua::Client, state: &AtomicU8) {
+fn background_task(client: &ua::Client, state: &AtomicU8) {
     log::info!("Starting background task");
 
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.
@@ -760,7 +761,8 @@ fn background_thread(client: &ua::Client, state: &AtomicU8) {
     // Run until cancelled. The only other way to exit is when `UA_Client_run_iterate()` fails which
     // happens when the connection is broken and the client instance cannot be used anymore.
     while let state = state.load(Ordering::Relaxed)
-        && state != BackgroundTheadState::Cancelled(BackgroundTheadCancelledState::Aborted).to_u8()
+        && state
+            != BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap).to_u8()
     {
         // Track time of iteration start to report iteration times below.
         let start_of_iteration = Instant::now();
@@ -772,7 +774,7 @@ fn background_thread(client: &ua::Client, state: &AtomicU8) {
             // _not_ held for the entire time though, so we can send out requests concurrently while
             // the client is running the iteration.
             //
-            // The invocation returns with the current connect status.
+            // The invocation returns the current connect status of the client.
             unsafe {
                 UA_Client_run_iterate(
                     // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
@@ -781,34 +783,43 @@ fn background_thread(client: &ua::Client, state: &AtomicU8) {
                 )
             }
         });
-        if let Err(err) = Error::verify_good(&connect_status) {
-            match connect_status.into_raw() {
-                UA_STATUSCODE_BADDISCONNECT
-                | UA_STATUSCODE_BADCONNECTIONCLOSED
-                | UA_STATUSCODE_BADCONNECTIONREJECTED => {
-                    // Not an error.
-                    if state
-                        == BackgroundTheadState::Cancelled(
-                            BackgroundTheadCancelledState::TerminateAfterNotConnected,
-                        )
-                        .to_u8()
-                    {
-                        log::info!("Terminating background task after not connected");
-                        return;
-                    }
-                }
-                _ => {
-                    // Unexpected error.
-                    log::error!("Terminating background task after unexpected error: {err:#}");
-                    return;
-                }
-            }
-        }
-
         let time_taken = start_of_iteration.elapsed();
         log::trace!("Iterate run took {time_taken:?}");
+
+        if let Err(error) = Error::verify_good(&connect_status) {
+            let not_connected = matches!(
+                connect_status.into_raw(),
+                UA_STATUSCODE_BADDISCONNECT
+                    | UA_STATUSCODE_BADCONNECTIONCLOSED
+                    | UA_STATUSCODE_BADCONNECTIONREJECTED
+            );
+            if state
+                == BackgroundTaskState::Cancelled(
+                    BackgroundTaskCancelledState::TerminateAfterNotConnected,
+                )
+                .to_u8()
+            {
+                if not_connected {
+                    log::info!("Terminating background task after not connected: {error}");
+                } else {
+                    log::error!("Terminating background task on unexpected error: {error}");
+                }
+                return;
+            }
+            if not_connected {
+                log::info!("Background task connect status: {error}");
+            } else {
+                // TODO: Handle more status codes?
+                log::error!("Unexpected error in background task: {error}");
+            }
+            // Continue until cancelled.
+        }
     }
 
+    debug_assert_ne!(
+        state.load(Ordering::Relaxed),
+        BackgroundTaskState::Running.to_u8()
+    );
     log::info!("Terminating cancelled background task");
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -132,8 +132,10 @@ impl AsyncClient {
         // `TerminateAfterNotConnected` mode keeps the asynchronous handling running until the
         // connection has been taken down, at which point the background task can finish and we wait
         // for that completion here.
-        background_thread.cancel(BackgroundTaskCancelledState::TerminateAfterNotConnected);
-        background_thread.wait_until_finished().await;
+        background_thread.cancel(BackgroundTaskCancellationMode::TerminateAfterNotConnected);
+        background_thread
+            .wait_until_finished_after_cancelled()
+            .await;
     }
 
     /// Reads node value.
@@ -585,7 +587,8 @@ impl Drop for AsyncClient {
         };
 
         log::info!("Cancelling and joining background task when dropping client");
-        background_thread.cancel_and_join(BackgroundTaskCancelledState::TerminateAsap);
+        background_thread.cancel(BackgroundTaskCancellationMode::TerminateAsap);
+        background_thread.join_after_cancelled();
 
         log::info!("Background task finished when dropping client");
     }
@@ -633,22 +636,18 @@ impl BackgroundThread {
             && !self.handle.is_finished()
     }
 
-    fn cancel(&self, cancelled: BackgroundTaskCancelledState) {
+    fn cancel(&self, mode: BackgroundTaskCancellationMode) {
         self.state.store(
-            BackgroundTaskState::Cancelled(cancelled).to_u8(),
+            BackgroundTaskState::Cancelled { mode }.to_u8(),
             Ordering::Relaxed,
         );
     }
 
-    fn cancel_and_join(self, cancelled: BackgroundTaskCancelledState) {
+    fn join_after_cancelled(self) {
         let Self { state, handle, .. } = self;
-
-        // Notify background task to cancel itself, even when [`UA_Client_run_iterate()`] would want
-        // to keep on running. This is okay: we are not issuing asynchronous requests anymore anyway
-        // (the only other call will be `UA_Client_delete()` when inner client drops).
-        state.store(
-            BackgroundTaskState::Cancelled(cancelled).to_u8(),
-            Ordering::Relaxed,
+        debug_assert_ne!(
+            state.load(Ordering::Relaxed),
+            BackgroundTaskState::Running.to_u8()
         );
 
         // We need to wait for the task to finish and must do so blockingly. `UA_Client_delete()` is
@@ -688,7 +687,7 @@ impl BackgroundThread {
         let _unused = handle.join();
     }
 
-    async fn wait_until_finished(self) {
+    async fn wait_until_finished_after_cancelled(self) {
         let Self {
             state,
             handle,
@@ -714,24 +713,26 @@ impl BackgroundThread {
 #[derive(Debug, Clone, Copy)]
 enum BackgroundTaskState {
     Running,
-    Cancelled(BackgroundTaskCancelledState),
+    Cancelled {
+        mode: BackgroundTaskCancellationMode,
+    },
 }
 
 impl BackgroundTaskState {
-    // Conversion to u8 is needed to store the state in an AtomicU8.
+    // Map all possible states to u8 that could be store in an AtomicUi.
     const fn to_u8(self) -> u8 {
         match self {
             Self::Running => 0,
-            Self::Cancelled(cancelled) => match cancelled {
-                BackgroundTaskCancelledState::TerminateAfterNotConnected => 1,
-                BackgroundTaskCancelledState::TerminateAsap => 2,
+            Self::Cancelled { mode } => match mode {
+                BackgroundTaskCancellationMode::TerminateAfterNotConnected => 1,
+                BackgroundTaskCancellationMode::TerminateAsap => 2,
             },
         }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
-enum BackgroundTaskCancelledState {
+enum BackgroundTaskCancellationMode {
     /// Terminate gracefully by servicing all pending requests until no longer connected.
     TerminateAfterNotConnected,
     /// Terminate as soon as possible.
@@ -759,7 +760,10 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
     loop {
         let current_state = state.load(Ordering::Relaxed);
         if current_state
-            == BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap).to_u8()
+            == (BackgroundTaskState::Cancelled {
+                mode: BackgroundTaskCancellationMode::TerminateAsap,
+            })
+            .to_u8()
         {
             log::info!("Terminating cancelled background task");
             break;
@@ -767,9 +771,9 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
         debug_assert!(
             current_state == BackgroundTaskState::Running.to_u8()
                 || current_state
-                    == BackgroundTaskState::Cancelled(
-                        BackgroundTaskCancelledState::TerminateAfterNotConnected
-                    )
+                    == BackgroundTaskState::Cancelled {
+                        mode: BackgroundTaskCancellationMode::TerminateAfterNotConnected
+                    }
                     .to_u8()
         );
 
@@ -803,9 +807,9 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
                     | UA_STATUSCODE_BADCONNECTIONREJECTED
             );
             if current_state
-                == BackgroundTaskState::Cancelled(
-                    BackgroundTaskCancelledState::TerminateAfterNotConnected,
-                )
+                == (BackgroundTaskState::Cancelled {
+                    mode: BackgroundTaskCancellationMode::TerminateAfterNotConnected,
+                })
                 .to_u8()
             {
                 if not_connected {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -111,21 +111,18 @@ impl AsyncClient {
         // allows us to take an early return path there.
         let background_thread = self.background_thread.take().expect("no background thread");
 
-        // Disconnecting requires driving the internal event loop.
-        if background_thread.is_running_and_not_finished_yet() {
-            let status_code = ua::StatusCode::new(unsafe {
-                UA_Client_disconnectAsync(
-                    // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
-                    self.client.as_ptr().cast_mut(),
-                )
-            });
-            if let Err(error) = Error::verify_good(&status_code) {
-                log::warn!("Error while disconnecting client: {error}");
-            }
-        } else {
-            log::info!(
-                "Cannot disconnect client because background thread is not running or has already finished"
-            );
+        // The background thread has not been cancelled yet, because it is only cancelled here
+        // or in drop(). It doesn't terminate and finish on its own before being cancelled.
+        debug_assert!(background_thread.is_running_and_not_finished_yet());
+
+        let status_code = ua::StatusCode::new(unsafe {
+            UA_Client_disconnectAsync(
+                // SAFETY: Cast to `mut` pointer, function is marked `UA_THREADSAFE`.
+                self.client.as_ptr().cast_mut(),
+            )
+        });
+        if let Err(error) = Error::verify_good(&status_code) {
+            log::warn!("Error while disconnecting client: {error}");
         }
 
         // Asynchronously wait for the background task running in the background thread to complete.
@@ -585,6 +582,10 @@ impl Drop for AsyncClient {
             log::debug!("Background task has already finished before dropping client");
             return;
         };
+
+        // The background thread has not been cancelled yet, because it is only cancelled here
+        // or in disconnect(). It doesn't terminate and finish on its own before being cancelled.
+        debug_assert!(background_thread.is_running_and_not_finished_yet());
 
         log::info!("Cancelling and joining background task when dropping client");
         background_thread.cancel(BackgroundTaskCancellationMode::TerminateAsap);

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -663,34 +663,36 @@ impl BackgroundThread {
         // TODO: Use `tracing` and span to group log messages.
         log::info!("Waiting for background task to finish after cancelling");
 
+        let join_background_thread_blocking = move || {
+            let _unused = handle.join();
+        };
+
         // `AsyncClient` is supposed to be used in asynchronous context. Note that blocking executor
         // threads may cause deadlocks and must be avoided.
         #[cfg(feature = "tokio")]
         if let Ok(rt) = &tokio::runtime::Handle::try_current() {
+            // Asynchronous context.
             if matches!(
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
-                // Blocking the current thread would panic.
-                rt.spawn_blocking(move || {
-                    let _unused = handle.join();
-                });
+                log::warn!("Blocking executor thread to join background thread");
+                // Continue below.
             } else {
-                // Offload the synchronous invocation from the executor thread onto a worker thread.
-                let join_handle = rt.spawn_blocking(move || {
-                    let _unused = handle.join();
-                });
+                // Offload the synchronous, blocking invocation from the executor thread
+                // onto a worker thread.
+                let join_handle = rt.spawn_blocking(join_background_thread_blocking);
                 // Re-enter the asynchronous context for joining the worker thread.
                 tokio::task::block_in_place(move || {
                     rt.block_on(async move {
                         let _unused = join_handle.await;
                     });
                 });
+                return;
             }
-            return;
         }
 
-        let _unused = handle.join();
+        join_background_thread_blocking();
     }
 
     async fn join_after_cancelled(self) {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -536,9 +536,9 @@ impl AsyncClient {
             .as_ref()
             .is_none_or(|background_thread| !background_thread.is_running_and_not_finished_yet())
         {
-            return Err(Error::Internal(
-                "background processing not running; async request cannot be serviced",
-            ));
+            return Err(Error::new(ua::StatusCode::new(
+                UA_STATUSCODE_BADDISCONNECT,
+            )));
         }
         log::debug!("Running {}", R::type_name());
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -676,6 +676,7 @@ impl BackgroundThread {
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
+                // Using tokio::task::block_in_place() here would panic.
                 log::warn!("Blocking executor thread to join background thread");
                 // Continue below.
             } else {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -760,10 +760,23 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
 
     // Run until cancelled. The only other way to exit is when `UA_Client_run_iterate()` fails which
     // happens when the connection is broken and the client instance cannot be used anymore.
-    while let state = state.load(Ordering::Relaxed)
-        && state
-            != BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap).to_u8()
-    {
+    loop {
+        let state = state.load(Ordering::Relaxed);
+        if state
+            == BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap).to_u8()
+        {
+            log::info!("Terminating cancelled background task");
+            break;
+        }
+        debug_assert!(
+            state == BackgroundTaskState::Running.to_u8()
+                || state
+                    == BackgroundTaskState::Cancelled(
+                        BackgroundTaskCancelledState::TerminateAfterNotConnected
+                    )
+                    .to_u8()
+        );
+
         // Track time of iteration start to report iteration times below.
         let start_of_iteration = Instant::now();
 
@@ -800,9 +813,13 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
                 .to_u8()
             {
                 if not_connected {
-                    log::info!("Terminating background task after not connected: {error}");
+                    log::info!(
+                        "Terminating cancelled background task after not connected: {error}"
+                    );
                 } else {
-                    log::error!("Terminating background task on unexpected error: {error}");
+                    log::error!(
+                        "Terminating cancelled background task on unexpected error: {error}"
+                    );
                 }
                 return;
             }
@@ -815,12 +832,6 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
             // Continue until cancelled.
         }
     }
-
-    debug_assert_ne!(
-        state.load(Ordering::Relaxed),
-        BackgroundTaskState::Running.to_u8()
-    );
-    log::info!("Terminating cancelled background task");
 }
 
 /// Converts [`ua::BrowseResult`] to our public result type.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -649,7 +649,7 @@ impl BackgroundThread {
         let Self {
             state,
             handle,
-            terminated_rx,
+            terminated_rx: _,
         } = self;
         debug_assert_ne!(
             state.load(Ordering::Relaxed),
@@ -667,16 +667,14 @@ impl BackgroundThread {
         // threads may cause deadlocks and must be avoided.
         #[cfg(feature = "tokio")]
         if let Ok(rt) = &tokio::runtime::Handle::try_current() {
-            let mut terminated_rx = terminated_rx;
             if matches!(
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
-                // Do not spawn new thread, because we do not have multiple threads in this runtime.
-                tokio::task::block_in_place(move || {
+                // Blocking the current thread would panic.
+                rt.spawn_blocking(move || {
                     let _unused = handle.join();
                 });
-                debug_assert!(terminated_rx.try_recv().is_err());
             } else {
                 // Offload the synchronous invocation from the executor thread onto a worker thread.
                 let join_handle = rt.spawn_blocking(move || {
@@ -686,14 +684,11 @@ impl BackgroundThread {
                 tokio::task::block_in_place(move || {
                     rt.block_on(async move {
                         let _unused = join_handle.await;
-                        debug_assert!(terminated_rx.try_recv().is_err());
                     });
                 });
             }
             return;
         }
-        #[cfg(not(feature = "tokio"))]
-        drop(terminated_rx);
 
         let _unused = handle.join();
     }
@@ -722,9 +717,21 @@ impl BackgroundThread {
 
         // After the background task has terminated the background thread should finish instantly.
         #[cfg(feature = "tokio")]
-        tokio::task::block_in_place(move || {
-            let _unused = handle.join();
-        });
+        {
+            let rt = tokio::runtime::Handle::current();
+            if matches!(
+                rt.runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::CurrentThread
+            ) {
+                tokio::task::spawn_blocking(move || {
+                    let _unused = handle.join();
+                });
+            } else {
+                tokio::task::block_in_place(move || {
+                    let _unused = handle.join();
+                });
+            }
+        }
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -538,7 +538,9 @@ impl AsyncClient {
             .as_ref()
             .is_none_or(|background_thread| !background_thread.is_running_and_not_finished_yet())
         {
-            return Err(Error::Internal("no background thread"));
+            return Err(Error::Internal(
+                "background processing not running; async request cannot be serviced",
+            ));
         }
         log::debug!("Running {}", R::type_name());
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -755,6 +755,7 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
     let timeout_millis = u32::try_from(RUN_ITERATE_TIMEOUT.as_millis()).unwrap_or(u32::MAX);
 
     // Run until cancelled.
+    let mut last_connect_status = ua::StatusCode::GOOD;
     loop {
         let current_state = state.load(Ordering::Relaxed);
         if current_state
@@ -796,7 +797,7 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
 
         if let Err(error) = Error::verify_good(&connect_status) {
             let not_connected = matches!(
-                connect_status.into_raw(),
+                connect_status.clone().into_raw(),
                 UA_STATUSCODE_BADDISCONNECT
                     | UA_STATUSCODE_BADCONNECTIONCLOSED
                     | UA_STATUSCODE_BADCONNECTIONREJECTED
@@ -818,14 +819,18 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
                 }
                 return;
             }
-            if not_connected {
-                log::info!("Background task connect status: {error}");
-            } else {
-                // TODO: Handle more status codes?
-                log::error!("Unexpected error in background task: {error}");
+            // Only log each bad connect status once after its first occurrence.
+            if connect_status != last_connect_status {
+                if not_connected {
+                    log::info!("Bad connect status in background task: {error}");
+                } else {
+                    // TODO: Handle more status codes?
+                    log::error!("Unexpected error in background task: {error}");
+                }
             }
             // Continue until cancelled.
         }
+        last_connect_status = connect_status;
     }
 }
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -721,14 +721,17 @@ impl BackgroundThread {
         // After the background task has terminated the background thread should finish instantly.
         #[cfg(feature = "tokio")]
         {
+            // This `async fn` is supposed to run on a Tokio executor thread.
+            // Otherwise obtaining a runtime handle would panic as expected.
             let rt = tokio::runtime::Handle::current();
             if matches!(
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
-                tokio::task::spawn_blocking(move || {
+                let _unused = tokio::task::spawn_blocking(move || {
                     let _unused = handle.join();
-                });
+                })
+                .await;
             } else {
                 tokio::task::block_in_place(move || {
                     let _unused = handle.join();

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -763,8 +763,7 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
     // `UA_Client_run_iterate()` expects the timeout to be given in milliseconds.
     let timeout_millis = u32::try_from(RUN_ITERATE_TIMEOUT.as_millis()).unwrap_or(u32::MAX);
 
-    // Run until cancelled. The only other way to exit is when `UA_Client_run_iterate()` fails which
-    // happens when the connection is broken and the client instance cannot be used anymore.
+    // Run until cancelled.
     loop {
         let current_state = state.load(Ordering::Relaxed);
         if current_state

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::c_void,
-    panic, slice,
+    slice,
     sync::{
         Arc, Weak,
         atomic::{AtomicU8, Ordering},
@@ -612,20 +612,10 @@ impl BackgroundThread {
         let handle = {
             let state = Arc::clone(&state);
             thread::spawn(move || {
-                let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    let () = background_task(&client, &state);
-                }));
-                match result {
-                    Ok(()) => {
-                        let _unused = finished_tx.send(());
-                    }
-                    Err(panicked) => {
-                        let _unused = finished_tx.send(());
-                        // Forward the panic.
-                        panic::resume_unwind(panicked);
-                        // Unreachable
-                    }
-                }
+                let () = background_task(&client, &state);
+                // The send() is redundant here, because dropping the sender will also wake up and unblock the receiver.
+                // finished_tx will be dropped implicitly even if background_task() panics.
+                let _unused = finished_tx.send(());
             })
         };
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -728,6 +728,7 @@ impl BackgroundThread {
                 rt.runtime_flavor(),
                 tokio::runtime::RuntimeFlavor::CurrentThread
             ) {
+                // Using tokio::task::block_in_place() here would panic.
                 let _unused = tokio::task::spawn_blocking(move || {
                     let _unused = handle.join();
                 })

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -766,16 +766,16 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
     // Run until cancelled. The only other way to exit is when `UA_Client_run_iterate()` fails which
     // happens when the connection is broken and the client instance cannot be used anymore.
     loop {
-        let state = state.load(Ordering::Relaxed);
-        if state
+        let current_state = state.load(Ordering::Relaxed);
+        if current_state
             == BackgroundTaskState::Cancelled(BackgroundTaskCancelledState::TerminateAsap).to_u8()
         {
             log::info!("Terminating cancelled background task");
             break;
         }
         debug_assert!(
-            state == BackgroundTaskState::Running.to_u8()
-                || state
+            current_state == BackgroundTaskState::Running.to_u8()
+                || current_state
                     == BackgroundTaskState::Cancelled(
                         BackgroundTaskCancelledState::TerminateAfterNotConnected
                     )
@@ -811,7 +811,7 @@ fn background_task(client: &ua::Client, state: &AtomicU8) {
                     | UA_STATUSCODE_BADCONNECTIONCLOSED
                     | UA_STATUSCODE_BADCONNECTIONREJECTED
             );
-            if state
+            if current_state
                 == BackgroundTaskState::Cancelled(
                     BackgroundTaskCancelledState::TerminateAfterNotConnected,
                 )

--- a/tests/server_client.rs
+++ b/tests/server_client.rs
@@ -90,12 +90,12 @@ async fn open_server_and_connect(client_strategy: ClientStrategy) {
     background_thread.join().unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn open_server_and_connect_disconnect_client_current_thread() {
     open_server_and_connect(ClientStrategy::Disconnect).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn open_server_and_connect_drop_client_current_thread() {
     open_server_and_connect(ClientStrategy::Drop).await;
 }

--- a/tests/server_client.rs
+++ b/tests/server_client.rs
@@ -9,6 +9,12 @@ use std::{
 use open62541::{ClientBuilder, ServerBuilder, ua};
 use open62541_sys::UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO_PRODUCTNAME;
 
+#[derive(Debug)]
+enum ClientStrategy {
+    Disconnect,
+    Drop,
+}
+
 // This mirrors test `create_and_destroy_client()` in `open62541-sys`.
 #[test]
 fn create_and_destroy_client() {
@@ -17,8 +23,7 @@ fn create_and_destroy_client() {
 }
 
 // This mirrors test `open_server_and_connect()` in `open62541-sys`.
-#[tokio::test]
-async fn open_server_and_connect() {
+async fn open_server_and_connect(client_strategy: ClientStrategy) {
     // Initialize new server listening on random port.
     let (server, runner) = ServerBuilder::default()
         .server_urls(&["opc.tcp://127.0.0.1:0"])
@@ -70,10 +75,37 @@ async fn open_server_and_connect() {
             .contains("open62541 OPC UA Server")
     );
 
-    // Disconnect client.
-    client.disconnect().await;
+    // Disconnect or drop the client.
+    match client_strategy {
+        ClientStrategy::Disconnect => {
+            client.disconnect().await;
+        }
+        ClientStrategy::Drop => {
+            drop(client);
+        }
+    }
 
     // Shut down server.
     running.store(false, Ordering::Relaxed);
     background_thread.join().unwrap();
+}
+
+#[tokio::test]
+async fn open_server_and_connect_disconnect_client_current_thread() {
+    open_server_and_connect(ClientStrategy::Disconnect).await;
+}
+
+#[tokio::test]
+async fn open_server_and_connect_drop_client_current_thread() {
+    open_server_and_connect(ClientStrategy::Drop).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn open_server_and_connect_disconnect_client_multi_thread() {
+    open_server_and_connect(ClientStrategy::Disconnect).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn open_server_and_connect_drop_client_multi_thread() {
+    open_server_and_connect(ClientStrategy::Drop).await;
 }


### PR DESCRIPTION
Adjusts `AsyncClient` shutdown behavior so the background event-loop thread does not terminate prematurely on transient connection interruptions, and instead terminates only after an explicit cancellation mode is set.

Otherwise, after the background thread has finished no more requests could be serviced and async calls would remain pending forever.

Seems to improve handling of and recovery from connection loss.