### PR TITLE
ci: Fix macOS runner selection for Intel (x86_64) builds

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -32,6 +32,10 @@ jobs:
       matrix:
         # Keep target archs in sync with `test.yaml`. Use latest versions of
         # runner OS here and supported ones in `test.yaml`.
+        #
+        # macos-latest is only available for arm64 and no longer for x86_64.
+        #
+        # See also: <https://docs.github.com/en/actions/reference/runners/github-hosted-runners>
         include:
           - target: aarch64-apple-darwin
             runner_os: macos-latest
@@ -44,8 +48,6 @@ jobs:
             runner_os: windows-11-arm
           - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            runner_os: macos-latest
           - target: x86_64-pc-windows-msvc
             runner_os: windows-latest
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -32,10 +32,6 @@ jobs:
       matrix:
         # Keep target archs in sync with `test.yaml`. Use latest versions of
         # runner OS here and supported ones in `test.yaml`.
-        #
-        # macos-latest is only available for arm64 and no longer for x86_64.
-        #
-        # See also: <https://docs.github.com/en/actions/reference/runners/github-hosted-runners>
         include:
           - target: aarch64-apple-darwin
             runner_os: macos-latest
@@ -48,6 +44,9 @@ jobs:
             runner_os: windows-11-arm
           - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            # There is no macos-intel-latest runner.
+            runner_os: macos-intel-26
           - target: x86_64-pc-windows-msvc
             runner_os: windows-latest
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,11 +57,9 @@ jobs:
             runner_os: ubuntu-24.04
 
           - target: x86_64-apple-darwin
-            runner_os: macos-14
+            runner_os: macos-intel-15
           - target: x86_64-apple-darwin
-            runner_os: macos-15
-          - target: x86_64-apple-darwin
-            runner_os: macos-26
+            runner_os: macos-intel-26
 
           - target: x86_64-pc-windows-msvc
             runner_os: windows-2022


### PR DESCRIPTION
- Use `macos-intel-15`/`macos-intel-26` instead of `macos-15`/`macos-26`. `macos-14` is arm64/aarch64 only.
- Use `macos-intel-26` instead of `macos-latest`.