### PR TITLE
Fix ua::NodeId::byte_string panic on NUL bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix linker errors for build target `x86_64-linux-unknown-gnu` by updating `open62541-sys` to
   version 0.5.4 ([#288](https://github.com/HMIProject/open62541/issues/288)).
 - Improve handling of and recovery from connection loss in `AsyncClient`.
-- Fix `ua::NodeId::byte_string` to allow byte strings that contain NUL bytes.
+- Fix `ua::NodeId::byte_string()` to allow byte strings that contain NUL bytes.
 
 ## [0.10.1] - 2025-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add methods `null()` and `is_null()` to `ua::String` and `ua::ByteString`.
 - Add method `new()` to `ua::ExpandedNodeId`.
 - Add `From`/`Into` conversion from `ua::NodeId` to `ua::ExpandedNodeId`.
-- Fix `ua::NodeId::byte_string` to allow byte strings that contain NUL bytes.
 
 ### Changed
 
@@ -36,6 +35,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix linker errors for build target `x86_64-linux-unknown-gnu` by updating `open62541-sys` to
   version 0.5.4 ([#288](https://github.com/HMIProject/open62541/issues/288)).
 - Improve handling of and recovery from connection loss in `AsyncClient`.
+- Fix `ua::NodeId::byte_string` to allow byte strings that contain NUL bytes.
 
 ## [0.10.1] - 2025-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add methods `null()` and `is_null()` to `ua::String` and `ua::ByteString`.
 - Add method `new()` to `ua::ExpandedNodeId`.
 - Add `From`/`Into` conversion from `ua::NodeId` to `ua::ExpandedNodeId`.
+- Fix `ua::NodeId::byte_string` to allow byte strings that contain NUL bytes.
 
 ### Changed
 

--- a/src/ua/data_types/byte_string.rs
+++ b/src/ua/data_types/byte_string.rs
@@ -29,14 +29,23 @@ impl ByteString {
             // not actually mutate the value, it only reads from it.
             data: s.as_ptr().cast_mut(),
         };
+
         // We let `UA_ByteString_copy()` do the heavy lifting of allocating memory and copying data.
         let status_code =
             ua::StatusCode::new(unsafe { UA_ByteString_copy(&raw const src, dst.as_mut_ptr()) });
+
         // PANIC: The only possible errors here are out-of-memory.
         assert!(
             status_code.is_good(),
             "byte string should have been created"
         );
+
+        // byte string cmp would be expensive in release, but `debug_assert` should be fine enough
+        debug_assert!(
+            matches!(dst.as_bytes(), Some(dst_bytes) if dst_bytes.len() == s.len()),
+            "byte string was corrupted after allocation"
+        );
+
         dst
     }
 

--- a/src/ua/data_types/byte_string.rs
+++ b/src/ua/data_types/byte_string.rs
@@ -40,12 +40,6 @@ impl ByteString {
             "byte string should have been created"
         );
 
-        // byte string cmp would be expensive in release, but `debug_assert` should be fine enough
-        debug_assert!(
-            matches!(dst.as_bytes(), Some(dst_bytes) if dst_bytes.len() == s.len()),
-            "byte string was corrupted after allocation"
-        );
-
         dst
     }
 

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -1,8 +1,8 @@
 use std::{ffi::CString, fmt, hash, str};
 
 use open62541_sys::{
-    UA_NODEID_BYTESTRING_ALLOC, UA_NODEID_GUID, UA_NODEID_NULL, UA_NODEID_NUMERIC,
-    UA_NODEID_STRING_ALLOC, UA_NodeId_hash, UA_NodeId_parse, UA_NodeId_print, UA_NodeIdType,
+    UA_NODEID_GUID, UA_NODEID_NULL, UA_NODEID_NUMERIC, UA_NODEID_STRING_ALLOC, UA_NodeId_hash,
+    UA_NodeId_parse, UA_NodeId_print, UA_NodeIdType,
 };
 
 use crate::{DataType, Error, ua};
@@ -77,34 +77,22 @@ impl NodeId {
     ///
     /// # Panics
     ///
-    /// The byte string identifier must not contain any NUL bytes.
+    /// Enough memory must be available to copy the byte string to the heap.
     #[must_use]
     pub fn byte_string(ns_index: u16, byte_string: &[u8]) -> Self {
-        // Unfortunately, `UA_NODEID_BYTESTRING_ALLOC` requires a NUL-terminated C `char` pointer to
-        // the buffer. This imposes the restriction that no node IDs with NUL bytes can be created.
-        let byte_string =
-            CString::new(byte_string).expect("node ID byte string does not contain NUL bytes");
-
-        // String allocation can fail but `UA_NODEID_BYTESTRING_ALLOC` does not tell us this when it
-        // happens. Instead, we end up with a well-defined node ID that has an empty byte string.
-        let inner = unsafe { UA_NODEID_BYTESTRING_ALLOC(ns_index, byte_string.as_ptr()) };
+        let byte_string = ua::ByteString::new(byte_string);
+        let mut node_id = Self::init();
+        node_id.0.namespaceIndex = ns_index;
+        node_id.0.identifierType = UA_NodeIdType::UA_NODEIDTYPE_BYTESTRING;
+        // SAFETY: We just selected the byte string identifier variant.
+        *unsafe { node_id.0.identifier.byteString.as_mut() } = byte_string.into_raw();
         debug_assert_eq!(
-            inner.identifierType,
+            node_id.0.identifierType,
             UA_NodeIdType::UA_NODEIDTYPE_BYTESTRING,
             "new node ID should have byte string type"
         );
 
-        // SAFETY: We have checked that we have this enum variant.
-        let identifier = unsafe { inner.identifier.byteString.as_ref() };
-        if !byte_string.is_empty() && (identifier.data.is_null() || identifier.length == 0) {
-            debug_assert!(
-                identifier.data.is_null(),
-                "unexpected node ID byte string data"
-            );
-            panic!("node ID byte string should have been allocated");
-        }
-
-        Self(inner)
+        node_id
     }
 
     /// Creates null node ID.
@@ -322,7 +310,7 @@ mod serde {
 
 #[cfg(test)]
 mod tests {
-    use std::str;
+    use std::{panic, str};
 
     use crate::ua;
 
@@ -339,5 +327,33 @@ mod tests {
         // Usually, parsing is done via `parse()` however which is implemented for `FromStr` target.
         //
         let _node_id: ua::NodeId = "ns=0;i=2258".parse().expect("should be valid node ID");
+    }
+
+    #[test]
+    fn byte_string_with_nul_bytes() {
+        const PAYLOAD: &[u8] = &[
+            1, 0, 0, 0, 166, 225, 42, 113, 138, 247, 51, 58, 186, 250, 45, 118, 134, 239, 96, 71,
+            140, 247, 64,
+        ];
+
+        let node_id = panic::catch_unwind(|| ua::NodeId::byte_string(2, PAYLOAD))
+            .expect("byte string node ID should allow NUL bytes");
+        let (ns_index, identifier) = node_id
+            .as_byte_string()
+            .expect("node ID should have byte string identifier");
+
+        assert_eq!(ns_index, 2);
+        assert_eq!(identifier.as_bytes(), Some(PAYLOAD));
+
+        let round_trip: ua::NodeId = node_id
+            .to_string()
+            .parse()
+            .expect("byte string node ID should round-trip");
+        let (ns_index, identifier) = round_trip
+            .as_byte_string()
+            .expect("round-tripped node ID should have byte string identifier");
+
+        assert_eq!(ns_index, 2);
+        assert_eq!(identifier.as_bytes(), Some(PAYLOAD));
     }
 }

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -89,12 +89,6 @@ impl NodeId {
         // SAFETY: We just selected the byte string identifier variant.
         *unsafe { node_id.0.identifier.byteString.as_mut() } = byte_string.into_raw();
 
-        debug_assert_eq!(
-            node_id.0.identifierType,
-            UA_NodeIdType::UA_NODEIDTYPE_BYTESTRING,
-            "new node ID should have byte string type"
-        );
-
         node_id
     }
 

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -349,7 +349,11 @@ mod tests {
             .expect("node ID should have byte string identifier");
 
         assert_eq!(ns, 1, "node ID namespace didn't match input");
-        assert_eq!(id.as_bytes(), Some(PAYLOAD), "node ID byte string should be empty");
+        assert_eq!(
+            id.as_bytes(),
+            Some(PAYLOAD),
+            "node ID byte string should be empty"
+        );
 
         let round_trip: ua::NodeId = node_id
             .to_string()
@@ -361,7 +365,11 @@ mod tests {
             .expect("round-tripped node ID should have byte string identifier");
 
         assert_eq!(ns, 1, "namespace index should match initial");
-        assert_eq!(id.as_bytes(), Some(PAYLOAD), "node ID byte string should be empty");
+        assert_eq!(
+            id.as_bytes(),
+            Some(PAYLOAD),
+            "node ID byte string should be empty"
+        );
     }
 
     #[test]

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -339,6 +339,32 @@ mod tests {
     }
 
     #[test]
+    fn empty_byte_string() {
+        const PAYLOAD: &[u8] = &[];
+        let node_id = panic::catch_unwind(|| ua::NodeId::byte_string(1, PAYLOAD))
+            .expect("byte string node ID should allow empty byte strings");
+
+        let (ns, id) = node_id
+            .as_byte_string()
+            .expect("node ID should have byte string identifier");
+
+        assert_eq!(ns, 1, "node ID namespace didn't match input");
+        assert_eq!(id.as_bytes(), Some(PAYLOAD), "node ID byte string should be empty");
+
+        let round_trip: ua::NodeId = node_id
+            .to_string()
+            .parse()
+            .expect("byte string node ID should round-trip");
+
+        let (ns, id) = round_trip
+            .as_byte_string()
+            .expect("round-tripped node ID should have byte string identifier");
+
+        assert_eq!(ns, 1, "namespace index should match initial");
+        assert_eq!(id.as_bytes(), Some(PAYLOAD), "node ID byte string should be empty");
+    }
+
+    #[test]
     fn byte_string_with_nul_bytes() {
         const PAYLOAD: &[u8] = &[
             1, 0, 0, 0, 166, 225, 42, 113, 138, 247, 51, 58, 186, 250, 45, 118, 134, 239, 96, 71,
@@ -347,6 +373,7 @@ mod tests {
 
         let node_id = panic::catch_unwind(|| ua::NodeId::byte_string(2, PAYLOAD))
             .expect("byte string node ID should allow NUL bytes");
+
         let (ns_index, identifier) = node_id
             .as_byte_string()
             .expect("node ID should have byte string identifier");
@@ -358,6 +385,7 @@ mod tests {
             .to_string()
             .parse()
             .expect("byte string node ID should round-trip");
+
         let (ns_index, identifier) = round_trip
             .as_byte_string()
             .expect("round-tripped node ID should have byte string identifier");

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -79,13 +79,22 @@ impl NodeId {
     ///
     /// Enough memory must be available to copy the byte string to the heap.
     #[must_use]
-    pub fn byte_string(ns_index: u16, byte_string: &[u8]) -> Self {
-        let byte_string = ua::ByteString::new(byte_string);
+    pub fn byte_string(ns_index: u16, bytes: &[u8]) -> Self {
+        let byte_string = ua::ByteString::new(bytes);
+
+        debug_assert!(
+            matches!(byte_string.as_bytes(), Some(new_bytes) if new_bytes.len() == bytes.len()),
+            "allocated node id byte string is corrupted"
+        );
+
         let mut node_id = Self::init();
+
         node_id.0.namespaceIndex = ns_index;
         node_id.0.identifierType = UA_NodeIdType::UA_NODEIDTYPE_BYTESTRING;
+
         // SAFETY: We just selected the byte string identifier variant.
         *unsafe { node_id.0.identifier.byteString.as_mut() } = byte_string.into_raw();
+
         debug_assert_eq!(
             node_id.0.identifierType,
             UA_NodeIdType::UA_NODEIDTYPE_BYTESTRING,

--- a/src/ua/data_types/node_id.rs
+++ b/src/ua/data_types/node_id.rs
@@ -81,12 +81,6 @@ impl NodeId {
     #[must_use]
     pub fn byte_string(ns_index: u16, bytes: &[u8]) -> Self {
         let byte_string = ua::ByteString::new(bytes);
-
-        debug_assert!(
-            matches!(byte_string.as_bytes(), Some(new_bytes) if new_bytes.len() == bytes.len()),
-            "allocated node id byte string is corrupted"
-        );
-
         let mut node_id = Self::init();
 
         node_id.0.namespaceIndex = ns_index;


### PR DESCRIPTION
Closes #338 
- Build byte-string node IDs directly from `ua::ByteString` instead of converting through a C string, so identifiers may contain embedded NUL bytes.
- Add regression coverage for NUL-containing byte-string node IDs, including parse/print round-tripping.