### PR TITLE
ci: Replace Ubuntu 22.04 with 26.04

### DIFF
--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -38,7 +38,8 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner_os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
-            runner_os: ubuntu-latest
+            # There is no ubuntu-latest-arm runner.
+            runner_os: ubuntu-26.04-arm
           - target: aarch64-pc-windows-msvc
             # There is no windows-latest-arm runner.
             runner_os: windows-11-arm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,22 +39,24 @@ jobs:
             runner_os: macos-26
 
           - target: aarch64-unknown-linux-gnu
-            runner_os: ubuntu-22.04-arm
-          - target: aarch64-unknown-linux-gnu
             runner_os: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-gnu
+            runner_os: ubuntu-26.04-arm
 
           - target: aarch64-unknown-linux-musl
-            runner_os: ubuntu-22.04-arm
-          - target: aarch64-unknown-linux-musl
             runner_os: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-musl
+            runner_os: ubuntu-26.04-arm
 
           - target: aarch64-pc-windows-msvc
             runner_os: windows-11-arm
 
           - target: armv7-unknown-linux-gnueabihf
-            runner_os: ubuntu-22.04
-          - target: armv7-unknown-linux-gnueabihf
             runner_os: ubuntu-24.04
+          # Build on Ubuntu 26.04 fails: <https://github.com/Mbed-TLS/mbedtls/issues/9875>
+          # TODO: Re-enable when fixed.
+          #- target: armv7-unknown-linux-gnueabihf
+          #  runner_os: ubuntu-26.04
 
           - target: x86_64-apple-darwin
             runner_os: macos-15-intel
@@ -67,14 +69,14 @@ jobs:
             runner_os: windows-2025
 
           - target: x86_64-unknown-linux-gnu
-            runner_os: ubuntu-22.04
-          - target: x86_64-unknown-linux-gnu
             runner_os: ubuntu-24.04
+          - target: x86_64-unknown-linux-gnu
+            runner_os: ubuntu-26.04
 
           - target: x86_64-unknown-linux-musl
-            runner_os: ubuntu-22.04
-          - target: x86_64-unknown-linux-musl
             runner_os: ubuntu-24.04
+          - target: x86_64-unknown-linux-musl
+            runner_os: ubuntu-26.04
 
     runs-on: ${{ matrix.runner_os }}
 
@@ -131,9 +133,6 @@ jobs:
           build --locked
 
       - name: Run tests (bins/lib/tests/examples) with feature combinations
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo hack --each-feature
           test --locked
@@ -146,9 +145,6 @@ jobs:
       # certain features only for some doctests, so we run them without
       # `cargo-hack`.
       - name: Run doctests with all features enabled
-        # Disable tests for musl libc target(s) due to build failure for unknown reasons.
-        # TODO: Try to re-enable this step regardless of the build target in the future.
-        if: ${{ !endsWith(matrix.target, '-musl') }}
         run: >-
           cargo test
           --locked --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -178,12 +178,12 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "open62541-sys"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c391efd372284037bf63d0d43249ff118cc25e94ec07d1a8a9508844c1cc2b6a"
+checksum = "f526df1235f5424f65a48c0bbd5ddec4277e1ce0ffdfca9bde0bfc262223e0a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -892,6 +892,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = ["src/", "README.md", "CHANGELOG.md", "LICENSES/MPL-2.0.txt"]
 futures-channel = "0.3.30"
 futures-core = { version = "0.3.30", default-features = false }
 log = "0.4.20"
-open62541-sys = "0.5.4"
+open62541-sys = "0.5.6"
 parking_lot = "0.12.4"
 paste = "1.0.14"
 serde = { version = "1.0.194", optional = true }


### PR DESCRIPTION
- Update to open62541-sys v0.5.6.
- Enable CI builds for all supported platforms.