### PR TITLE
Fix use-after-free of node lifecycle callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix use-after-free when a `Server` is used after its `ServerRunner` has been dropped (e.g.
+  `let (server, _) = builder.build();`). The node lifecycle callbacks borrowed by
+  `config.nodeLifecycle` are now owned by the shared server and outlive every server handle.
 - Fix linker errors for build target `x86_64-linux-unknown-gnu` by updating `open62541-sys` to
   version 0.5.4 ([#288](https://github.com/HMIProject/open62541/issues/288)).
 - Improve handling of and recovery from connection loss in `AsyncClient`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,8 @@ mod node_types;
 use std::{
     any::Any,
     ffi::{CString, c_void},
-    mem, ptr,
+    ops::Deref,
+    ptr,
     sync::Arc,
     time::Instant,
 };
@@ -275,18 +276,25 @@ impl ServerBuilder {
         debug_assert!(global_node_lifecycle.destructor.is_none());
         global_node_lifecycle.destructor = Some(destructor_c);
 
-        // SAFETY: We keep `global_node_lifecycle` alive until `clear_global_node_lifecycle()`.
+        // Point the server configuration at the heap-allocated callbacks. The `Box` is moved into the
+        // shared `SharedServer` below, which keeps it alive for as long as any `Server` or
+        // `ServerRunner` handle exists.
         unsafe { set_global_node_lifecycle(&mut config, &mut global_node_lifecycle) };
 
-        let server = Arc::new(ua::Server::new_with_config(config));
+        // `SharedServer` owns the `UA_Server` together with the node lifecycle callbacks that its
+        // configuration borrows via `config.nodeLifecycle`. Sharing it through `Arc` ties the lifetime
+        // of those callbacks to the server itself, not to the `ServerRunner`. This matters because
+        // `Server` and `ServerRunner` share ownership of the server and either one may outlive the
+        // other (e.g. `let (server, _) = builder.build();` drops the runner immediately).
+        let server = Arc::new(SharedServer {
+            server: ua::Server::new_with_config(config),
+            global_node_lifecycle,
+        });
         let state = Arc::new(RunnerState::new());
 
-        let runner = ServerRunner::new(
-            Arc::clone(&server),
-            global_node_lifecycle,
-            access_control_sentinel,
-            Arc::clone(&state),
-        );
+        // The access control sentinel is kept by the runner: access control is only consulted while
+        // the server is running, which requires the runner to be alive.
+        let runner = ServerRunner::new(Arc::clone(&server), access_control_sentinel, Arc::clone(&state));
         let server = Server { server, state };
         (server, runner)
     }
@@ -390,6 +398,37 @@ impl ServerConfigGuard<'_> {
     }
 }
 
+/// Owns the [`ua::Server`] together with the heap-allocated node lifecycle callbacks that its
+/// configuration borrows through a raw pointer.
+///
+/// The server configuration's `nodeLifecycle` field is a raw pointer into Rust-owned memory (see
+/// [`set_global_node_lifecycle()`]). That memory must stay valid for as long as the `UA_Server`
+/// exists and must only be freed *after* [`UA_Server_delete()`](open62541_sys::UA_Server_delete) has
+/// run, because deleting the server also deletes its nodes, which invokes the node destructor
+/// callback.
+///
+/// Both [`Server`] and [`ServerRunner`] share ownership of this value through [`Arc`], so the
+/// borrowed data outlives every server handle regardless of which one is dropped first. The fields
+/// are declared so that `server` (and thus `UA_Server_delete()`) is dropped *before*
+/// `global_node_lifecycle`.
+#[derive(Debug)]
+struct SharedServer {
+    server: ua::Server,
+
+    /// Heap-allocated set of callbacks pointed at by `config.nodeLifecycle`. Never read directly; it
+    /// exists solely to keep the callbacks alive for the configuration's raw pointer.
+    #[expect(dead_code, reason = "kept alive for `config.nodeLifecycle` to borrow")]
+    global_node_lifecycle: Box<UA_GlobalNodeLifecycle>,
+}
+
+impl Deref for SharedServer {
+    type Target = ua::Server;
+
+    fn deref(&self) -> &Self::Target {
+        &self.server
+    }
+}
+
 /// OPC UA server.
 ///
 /// This represents an OPC UA server. Nodes can be added through the several methods below.
@@ -398,7 +437,7 @@ impl ServerConfigGuard<'_> {
 /// from clients.
 #[derive(Debug, Clone)]
 pub struct Server {
-    server: Arc<ua::Server>,
+    server: Arc<SharedServer>,
     state: Arc<RunnerState>,
 }
 
@@ -1746,13 +1785,14 @@ impl Server {
 
 #[derive(Debug)]
 pub struct ServerRunner {
-    server: Arc<ua::Server>,
+    // Shares ownership of the server (and the node lifecycle callbacks its configuration borrows)
+    // with [`Server`].
+    server: Arc<SharedServer>,
 
-    /// Heap-allocated set of callbacks in `config.nodeLifecycle`.
-    global_node_lifecycle: Box<UA_GlobalNodeLifecycle>,
-
-    /// [`AccessControl`] instances may hold additional data that must be kept alive until server is
-    /// shut down. The sentinel value cleans this up when it is dropped.
+    /// [`AccessControl`] instances may hold additional data that must be kept alive while the server
+    /// is running. The sentinel value cleans this up when it is dropped (i.e. when the runner is
+    /// dropped, after the server has stopped). Never read directly.
+    #[expect(dead_code, reason = "kept alive for the running server to borrow")]
     access_control_sentinel: Option<Box<dyn Any + Send>>,
 
     state: Arc<RunnerState>,
@@ -1761,14 +1801,12 @@ pub struct ServerRunner {
 impl ServerRunner {
     #[must_use]
     fn new(
-        server: Arc<ua::Server>,
-        global_node_lifecycle: Box<UA_GlobalNodeLifecycle>,
+        server: Arc<SharedServer>,
         access_control_sentinel: Option<Box<dyn Any + Send>>,
         state: Arc<RunnerState>,
     ) -> Self {
         Self {
             server,
-            global_node_lifecycle,
             access_control_sentinel,
             state,
         }
@@ -1792,15 +1830,8 @@ impl ServerRunner {
     /// # Errors
     ///
     /// This fails when the server cannot be started.
-    pub fn run_until_interrupt(mut self) -> Result<()> {
-        let Self {
-            server,
-            global_node_lifecycle,
-            access_control_sentinel,
-            state,
-        } = &mut self;
-        let global_node_lifecycle = mem::take(global_node_lifecycle);
-        let access_control_sentinel = access_control_sentinel.take();
+    pub fn run_until_interrupt(self) -> Result<()> {
+        let Self { server, state, .. } = &self;
 
         let mut state_guard = state.lock();
 
@@ -1827,13 +1858,6 @@ impl ServerRunner {
             }
         }
 
-        unsafe { clear_global_node_lifecycle(server, global_node_lifecycle) };
-
-        // Compile-time assertion to make sure that the sentinel value was still around for the call
-        // above (including any branches that exit early with `?` or `return`): only when the server
-        // has finished shutting down, we are allowed to drop sentinel values.
-        drop(access_control_sentinel);
-
         Ok(())
     }
 
@@ -1845,15 +1869,8 @@ impl ServerRunner {
     /// # Errors
     ///
     /// This fails when the server cannot be started.
-    pub fn run_until_cancelled(mut self, mut is_cancelled: impl FnMut() -> bool) -> Result<()> {
-        let Self {
-            server,
-            global_node_lifecycle,
-            access_control_sentinel,
-            state,
-        } = &mut self;
-        let global_node_lifecycle = mem::take(global_node_lifecycle);
-        let access_control_sentinel = access_control_sentinel.take();
+    pub fn run_until_cancelled(self, mut is_cancelled: impl FnMut() -> bool) -> Result<()> {
+        let Self { server, state, .. } = &self;
 
         let mut state_guard = state.lock();
 
@@ -1927,13 +1944,6 @@ impl ServerRunner {
             }
         }
 
-        unsafe { clear_global_node_lifecycle(server, global_node_lifecycle) };
-
-        // Compile-time assertion to make sure that the sentinel value was still around for the call
-        // above (including any branches that exit early with `?` or `return`): only when the server
-        // has finished shutting down, we are allowed to drop sentinel values.
-        drop(access_control_sentinel);
-
         Ok(())
     }
 }
@@ -1968,8 +1978,8 @@ fn to_browse_result(result: &ua::BrowseResult) -> BrowseResult {
 ///
 /// This must be called before the server accesses `config.nodeLifecycle`.
 ///
-/// The boxed value `global_node_lifecycle` must be kept alive until `clear_global_node_lifecycle()`
-/// has been called.
+/// The boxed value `global_node_lifecycle` must be kept alive (and not moved out of its `Box`) until
+/// the server has been deleted. Ownership is transferred to [`SharedServer`], which guarantees this.
 unsafe fn set_global_node_lifecycle(
     config: &mut ua::ServerConfig,
     global_node_lifecycle: &mut Box<UA_GlobalNodeLifecycle>,
@@ -1979,29 +1989,8 @@ unsafe fn set_global_node_lifecycle(
     // PANIC: Nobody else has initialized the node lifecycle callbacks before.
     debug_assert!(config.nodeLifecycle.is_null());
 
-    // This stores the pointer to the `Box`-allocated `global_node_lifecycle` in the config; it must
-    // be kept alive elsewhere (e.g., in `ServerRunner`) until the server no longer accesses it.
+    // Store a pointer to the `Box`-allocated `global_node_lifecycle` in the config. The `Box` is kept
+    // alive by `SharedServer` for as long as the server exists; the heap address is stable across the
+    // move of the `Box` into `SharedServer`.
     config.nodeLifecycle = &raw mut *global_node_lifecycle.as_mut();
-}
-
-/// Clears `config.nodeLifecycle`.
-///
-/// # Safety
-///
-/// This must be called after the server has finished accessing `config.nodeLifecycle`.
-unsafe fn clear_global_node_lifecycle(
-    server: &ua::Server,
-    mut global_node_lifecycle: Box<UA_GlobalNodeLifecycle>,
-) {
-    // SAFETY: The server has finished execution and we can mutate the configuration.
-    let config = unsafe { &mut *UA_Server_getConfig(server.as_ptr().cast_mut()) };
-
-    debug_assert_eq!(
-        config.nodeLifecycle,
-        &raw mut *global_node_lifecycle.as_mut()
-    );
-
-    // Remove pointer to prevent server from making any more calls. `global_node_lifecycle` goes out
-    // of scope at the end of this function and gets freed.
-    config.nodeLifecycle = ptr::null_mut();
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -294,7 +294,11 @@ impl ServerBuilder {
 
         // The access control sentinel is kept by the runner: access control is only consulted while
         // the server is running, which requires the runner to be alive.
-        let runner = ServerRunner::new(Arc::clone(&server), access_control_sentinel, Arc::clone(&state));
+        let runner = ServerRunner::new(
+            Arc::clone(&server),
+            access_control_sentinel,
+            Arc::clone(&state),
+        );
         let server = Server { server, state };
         (server, runner)
     }


### PR DESCRIPTION
## Description

Fixes the doctest crashes (`SIGSEGV`/`SIGBUS`) surfacing on #310, e.g. [this CI run](https://github.com/HMIProject/open62541/actions/runs/29081971577/job/86326677274?pr=310). Targets the `open62541-1.5` branch so it can be reviewed separately from the version bump.

## Root cause

`UA_ServerConfig.nodeLifecycle` changed from an **inline struct** to a **pointer** in open62541 1.5:

```c
UA_GlobalNodeLifecycle *nodeLifecycle;   // server.h
```

`UA_Server_newWithConfig` copies the config (`server->config = *config`), i.e. it copies the *pointer* — the server now **borrows** the callbacks and their storage must outlive it.

The binding stored the callbacks in a `Box<UA_GlobalNodeLifecycle>` owned by `ServerRunner` and pointed `config.nodeLifecycle` at it. But `Server` and `ServerRunner` share the `UA_Server` through an `Arc<ua::Server>`, and either may outlive the other. Every server doctest uses the `Server` standalone:

```rust
let (server, _) = ServerBuilder::default().build();   // ServerRunner dropped immediately
server.add_node(/* … */)?;                             // uses the server without a runner
```

The bare `_` drops the `ServerRunner` right away, freeing the `Box`, while `server->config.nodeLifecycle` keeps pointing at the freed memory (`Drop for ServerRunner` never nulls it — only the `run_*` methods do). The next node constructor call inside open62541 (`recursiveCallConstructors`, reached from `add_node`) dereferences the freed pointer and jumps through a garbage function pointer → **use-after-free**.

Verified under lldb — at the first `add_node`, `server->config.nodeLifecycle` pointed 32 bytes (`sizeof(UA_GlobalNodeLifecycle)`) *before* the server allocation with garbage callbacks (`constructor = 0x2436`, varying per run). It only crashed on stricter allocators (musl, macOS, Windows/ARM); glibc-x86 happened to leave the freed slot intact, which is why only some matrix targets failed.

## Fix

Introduce a private `SharedServer` that owns the `ua::Server` together with the `Box<UA_GlobalNodeLifecycle>`, shared by both `Server` and `ServerRunner` via `Arc`. Field order guarantees the `Box` is dropped **after** `UA_Server_delete()` (which itself invokes node destructors). This ties the callbacks' lifetime to the server rather than the runner and removes the fragile `clear_global_node_lifecycle()` reclaim dance.

The access control sentinel intentionally stays with the `ServerRunner`: access control is only consulted while the server is running, which already requires the runner to be alive.

## Verification

- `cargo test --all-features --doc` → **38 passed, 0 failed** (previously 3 × SIGSEGV) on `aarch64-apple-darwin`.
- `cargo test --all-features --lib --tests` and `cargo clippy --all-features --all-targets` clean.
- Standalone repro (`let (server, _) = …; server.add_node(…)`) crashed before the fix, exits `0` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)