### PR TITLE
v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-13
+
 ### Added
 
 - Add method `ua::VariableAttributes::with_array_dimensions()`.
@@ -585,7 +587,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First public release.
 
-[Unreleased]: https://github.com/HMIProject/open62541/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/HMIProject/open62541/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/HMIProject/open62541/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/HMIProject/open62541/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/HMIProject/open62541/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/HMIProject/open62541/compare/v0.9.3...v0.9.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "open62541"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open62541"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["HMI Project"]
 edition = "2024"
 # Keep the MSRV number here in sync with `test.yaml`.


### PR DESCRIPTION
Aggregates all breaking changes into a new release.

The next release v0.12.0 will introduce breaking changes by upgrading from open62541 v1.4 to v1.5.