### PR TITLE
feat(path): expose `*Path`-related utility functions

### DIFF
--- a/src/ua/data_types/browse_path.rs
+++ b/src/ua/data_types/browse_path.rs
@@ -15,10 +15,12 @@ impl BrowsePath {
         self
     }
 
+    #[must_use]
     pub fn starting_node(&self) -> &ua::NodeId {
         ua::NodeId::raw_ref(&self.0.startingNode)
     }
 
+    #[must_use]
     pub fn relative_path(&self) -> &ua::RelativePath {
         ua::RelativePath::raw_ref(&self.0.relativePath)
     }

--- a/src/ua/data_types/browse_path.rs
+++ b/src/ua/data_types/browse_path.rs
@@ -14,4 +14,12 @@ impl BrowsePath {
         relative_path.clone_into_raw(&mut self.0.relativePath);
         self
     }
+
+    pub fn starting_node(&self) -> &ua::NodeId {
+        ua::NodeId::raw_ref(&self.0.startingNode)
+    }
+
+    pub fn relative_path(&self) -> &ua::RelativePath {
+        ua::RelativePath::raw_ref(&self.0.relativePath)
+    }
 }

--- a/src/ua/data_types/relative_path.rs
+++ b/src/ua/data_types/relative_path.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ptr;
 use std::str::FromStr;
 
@@ -20,62 +21,44 @@ impl RelativePath {
     pub fn elements(&self) -> Option<&[ua::RelativePathElement]> {
         // SAFETY: Lifetime of the slice is implicitly bound to the lifetime of the reference to self.
         // Pointer validity is checked in `Array::slice_from_raw_parts()`.
-        unsafe {
-            ua::Array::slice_from_raw_parts(self.0.elementsSize, self.0.elements)
-        }
+        unsafe { ua::Array::slice_from_raw_parts(self.0.elementsSize, self.0.elements) }
     }
 
     #[must_use]
     pub fn elements_mut(&mut self) -> Option<&mut [ua::RelativePathElement]> {
         // SAFETY: Lifetime of the slice is implicitly bound to the lifetime of the reference to self.
         // Pointer validity is checked in `Array::slice_from_raw_parts_mut()`.
-        unsafe {
-            ua::Array::slice_from_raw_parts_mut(self.0.elementsSize, self.0.elements)
-        }
+        unsafe { ua::Array::slice_from_raw_parts_mut(self.0.elementsSize, self.0.elements) }
     }
 
     /// Returns the number of elements in the relative path.
-    pub fn len(&self) -> usize {
+    #[must_use]
+    pub const fn len(&self) -> usize {
         self.0.elementsSize
     }
 
     /// Returns true if the relative path has no elements.
-    pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
         self.0.elementsSize == 0
     }
 
     /// Parses a relative path from a string, using the limited grammar implemented by open62541.
+    ///
+    /// # Errors
+    /// Will return an error if the string is not parseable as a relative path.
+    ///
     /// See [UA_RelativePath_parse](https://open62541.org/doc/master/util.html#example-relativepaths) docs.
     pub fn parse(path: &str) -> Result<Self, Error> {
         let path = ua::String::new(path)?;
         let mut slf = Self::init();
 
-        let result = unsafe {
-            UA_RelativePath_parse(slf.as_mut_ptr(), ptr::read(path.as_ptr()))
-        };
+        let result = unsafe { UA_RelativePath_parse(slf.as_mut_ptr(), ptr::read(path.as_ptr())) };
 
         let status_code = ua::StatusCode::new(result);
 
         if status_code.is_good() {
             Ok(slf)
-        } else {
-            Err(Error::new(status_code))
-        }
-    }
-
-    /// Renders the relative path as a string.
-    /// See [UA_RelativePath_print](https://open62541.org/doc/master/util.html#example-relativepaths) docs.
-    pub fn to_string(&self) -> Result<String, Error> {
-        let mut str = ua::String::null();
-
-        let status_code = ua::StatusCode::new(unsafe {
-            // SAFETY: `UA_RelativePath_print` will initialize the string if null.
-            // See UA_RelativePath_print docs (https://open62541.org/doc/master/util.html#example-relativepaths)
-            UA_RelativePath_print(&self.0, str.as_mut_ptr())
-        });
-
-        if status_code.is_good() {
-            Ok(str.to_string())
         } else {
             Err(Error::new(status_code))
         }
@@ -90,3 +73,24 @@ impl FromStr for RelativePath {
     }
 }
 
+impl fmt::Display for RelativePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut str = ua::String::null();
+
+        let status_code = ua::StatusCode::new(unsafe {
+            // SAFETY: `UA_RelativePath_print` will initialize the string if null.
+            // See UA_RelativePath_print docs (https://open62541.org/doc/master/util.html#example-relativepaths)
+            UA_RelativePath_print(&raw const self.0, str.as_mut_ptr())
+        });
+
+        // A lot of chained `UA_String_append` & `UA_String_escapeAppend`
+        // calls + an optimistic stack allocation w/ retry if the buffer is too small.
+        // SAFETY: `UA_RelativePath_print` will only return an error on a failed allocation.
+        debug_assert!(
+            status_code.is_good(),
+            "failed to print relative path: {status_code}"
+        );
+
+        write!(f, "{str}")
+    }
+}

--- a/src/ua/data_types/relative_path.rs
+++ b/src/ua/data_types/relative_path.rs
@@ -1,4 +1,5 @@
 use std::ptr;
+use std::str::FromStr;
 
 use open62541_sys::UA_RelativePath_parse;
 use open62541_sys::UA_RelativePath_print;
@@ -78,6 +79,14 @@ impl RelativePath {
         } else {
             Err(Error::new(status_code))
         }
+    }
+}
+
+impl FromStr for RelativePath {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
     }
 }
 

--- a/src/ua/data_types/relative_path.rs
+++ b/src/ua/data_types/relative_path.rs
@@ -33,14 +33,18 @@ impl RelativePath {
         }
     }
 
+    /// Returns the number of elements in the relative path.
     pub fn len(&self) -> usize {
         self.0.elementsSize
     }
 
+    /// Returns true if the relative path has no elements.
     pub fn is_empty(&self) -> bool {
         self.0.elementsSize == 0
     }
 
+    /// Parses a relative path from a string, using the limited grammar implemented by open62541.
+    /// See [UA_RelativePath_parse](https://open62541.org/doc/master/util.html#example-relativepaths) docs.
     pub fn parse(path: &str) -> Result<Self, Error> {
         let path = ua::String::new(path)?;
         let mut slf = Self::init();
@@ -58,6 +62,8 @@ impl RelativePath {
         }
     }
 
+    /// Renders the relative path as a string.
+    /// See [UA_RelativePath_print](https://open62541.org/doc/master/util.html#example-relativepaths) docs.
     pub fn to_string(&self) -> Result<String, Error> {
         let mut str = ua::String::null();
 

--- a/src/ua/data_types/relative_path.rs
+++ b/src/ua/data_types/relative_path.rs
@@ -1,4 +1,9 @@
-use crate::ua;
+use std::ptr;
+
+use open62541_sys::UA_RelativePath_parse;
+use open62541_sys::UA_RelativePath_print;
+
+use crate::{DataType as _, Error, ua};
 
 crate::data_type!(RelativePath);
 
@@ -9,4 +14,64 @@ impl RelativePath {
         array.move_into_raw(&mut self.0.elementsSize, &mut self.0.elements);
         self
     }
+
+    #[must_use]
+    pub fn elements(&self) -> Option<&[ua::RelativePathElement]> {
+        // SAFETY: Lifetime of the slice is implicitly bound to the lifetime of the reference to self.
+        // Pointer validity is checked in `Array::slice_from_raw_parts()`.
+        unsafe {
+            ua::Array::slice_from_raw_parts(self.0.elementsSize, self.0.elements)
+        }
+    }
+
+    #[must_use]
+    pub fn elements_mut(&mut self) -> Option<&mut [ua::RelativePathElement]> {
+        // SAFETY: Lifetime of the slice is implicitly bound to the lifetime of the reference to self.
+        // Pointer validity is checked in `Array::slice_from_raw_parts_mut()`.
+        unsafe {
+            ua::Array::slice_from_raw_parts_mut(self.0.elementsSize, self.0.elements)
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.elementsSize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.elementsSize == 0
+    }
+
+    pub fn parse(path: &str) -> Result<Self, Error> {
+        let path = ua::String::new(path)?;
+        let mut slf = Self::init();
+
+        let result = unsafe {
+            UA_RelativePath_parse(slf.as_mut_ptr(), ptr::read(path.as_ptr()))
+        };
+
+        let status_code = ua::StatusCode::new(result);
+
+        if status_code.is_good() {
+            Ok(slf)
+        } else {
+            Err(Error::new(status_code))
+        }
+    }
+
+    pub fn to_string(&self) -> Result<String, Error> {
+        let mut str = ua::String::null();
+
+        let status_code = ua::StatusCode::new(unsafe {
+            // SAFETY: `UA_RelativePath_print` will initialize the string if null.
+            // See UA_RelativePath_print docs (https://open62541.org/doc/master/util.html#example-relativepaths)
+            UA_RelativePath_print(&self.0, str.as_mut_ptr())
+        });
+
+        if status_code.is_good() {
+            Ok(str.to_string())
+        } else {
+            Err(Error::new(status_code))
+        }
+    }
 }
+

--- a/src/ua/data_types/relative_path_element.rs
+++ b/src/ua/data_types/relative_path_element.rs
@@ -27,18 +27,22 @@ impl RelativePathElement {
         self
     }
 
+    #[must_use]
     pub fn target_name(&self) -> &ua::QualifiedName {
         ua::QualifiedName::raw_ref(&self.0.targetName)
     }
 
+    #[must_use]
     pub const fn is_inverse(&self) -> bool {
         self.0.isInverse
     }
 
+    #[must_use]
     pub const fn include_subtypes(&self) -> bool {
         self.0.includeSubtypes
     }
 
+    #[must_use]
     pub fn reference_type_id(&self) -> &ua::NodeId {
         ua::NodeId::raw_ref(&self.0.referenceTypeId)
     }

--- a/src/ua/data_types/relative_path_element.rs
+++ b/src/ua/data_types/relative_path_element.rs
@@ -26,4 +26,20 @@ impl RelativePathElement {
         target_name.clone_into_raw(&mut self.0.targetName);
         self
     }
+
+    pub fn target_name(&self) -> &ua::QualifiedName {
+        ua::QualifiedName::raw_ref(&self.0.targetName)
+    }
+
+    pub const fn is_inverse(&self) -> bool {
+        self.0.isInverse
+    }
+
+    pub const fn include_subtypes(&self) -> bool {
+        self.0.includeSubtypes
+    }
+
+    pub fn reference_type_id(&self) -> &ua::NodeId {
+        ua::NodeId::raw_ref(&self.0.referenceTypeId)
+    }
 }


### PR DESCRIPTION
Closes #348 

Implements `UA_RelativePath` factories/methods:
- `UA_RelativePath_parse` -> `ua::RelativePath::parse() -> Result<Self>`
- `UA_RelativePath_print` -> `impl Display for ua::RelativePath`

Accesser methods were also implemented.